### PR TITLE
golangci-lint: switch to fieldalignment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,10 +11,11 @@ linters-settings:
       - unnamedResult
   gocyclo:
     min-complexity: 20
+  govet:
+    enable:
+      - fieldalignment
   lll:
     line-length: 140
-  maligned:
-    suggest-new: true
 linters:
   disable-all: true
   enable:
@@ -39,7 +40,6 @@ linters:
     - ineffassign
     - interfacer
     - lll
-    - maligned
     - misspell
     - nakedret
     - prealloc
@@ -77,3 +77,9 @@ issues:
         - stylecheck
       text: "ST1001: "
       path: test
+
+    # Ignore pointer bytes in struct alignment tests (this is a very
+    # minor optimisation)
+    - linters:
+        - govet
+      text: "pointer bytes could be"


### PR DESCRIPTION
fieldalignment replaces maligned. Errors related to pointer ordering
(for GC) are ignored; see https://github.com/golang/go/issues/44877
for details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>