### PR TITLE
Change dependabot to weekly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: k8s.io/api


### PR DESCRIPTION
Seems that AWS SDK get updated on an almost daily basis, and dependabot
is just flooding us with updates.
Change the schedule to weekly to lessen the effect.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>