### PR TITLE
Update dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,6 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     ignore:
-      - dependency-name: k8s.io/api
-        versions:
-          - "> 0.18.6"
-      - dependency-name: k8s.io/apimachinery
-        versions:
-          - "> 0.18.6"
-      - dependency-name: k8s.io/client-go
-        versions:
-          - "> 0.18.6"
+      - dependency-name: k8s.io/*
+      - dependency-name: sigs.k8s.io/*
       - dependency-name: github.com/submariner-io/*


### PR DESCRIPTION
We handle k8s manually so ignore all versions.
