### PR TITLE
Add CII badge, remove PR-triggered badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Submariner cloud-prepare
 
 <!-- markdownlint-disable line-length -->
-[![Linting](https://github.com/submariner-io/cloud-prepare/workflows/Linting/badge.svg)](https://github.com/submariner-io/cloud-prepare/actions?query=workflow%3ALinting)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4865/badge)](https://bestpractices.coreinfrastructure.org/projects/4865)
 <!-- markdownlint-enable line-length -->
 
 Submariner's cloud-prepare is a Go library that provides API and capabilities for setting up cloud infrastructure in order to install


### PR DESCRIPTION
Add Submariner's CII Best Practices badge to the README.

Remove badges for workflows triggered by PRs, as their status reflects
tests against proposed/WIP code, not merged code. This causes false red
flags, reducing the utility of the badges overall. Leave badges for
workflows run against merged code.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>