### PR TITLE
Support NoGateways when we want to use LoadBalancers

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -43,12 +43,19 @@ type PrepareForSubmarinerInput struct {
 	PublicPorts []PortSpec
 
 	// Amount of gateways that are being deployed
+	// -1 (NoGateways) = Deploy no dedicated gateways. This is used when creating a Network LoadBalancer
+	//                   to expose the gateway traffic.
 	//
-	// 0 = Deploy one gateway per public subnet (Default if not specified)
+	//  0 (AutoGateways) = Deploy one gateway per public subnet (Default if not specified)
 	//
 	// 1-* = Deploy the amount of gateways requested (May fail if there aren't enough public subnets)
 	Gateways int
 }
+
+const (
+	NoGateways   = -1
+	AutoGateways = 0
+)
 
 // Cloud is a potential cloud for installing Submariner on
 type Cloud interface {

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -105,6 +105,14 @@ func (ac *awsCloud) PrepareForSubmariner(input api.PrepareForSubmarinerInput, re
 		reporter.Succeeded("Opened port %v protocol %s for intra-cluster communications", port.Port, port.Protocol)
 	}
 
+	if input.Gateways > api.NoGateways {
+		return ac.preparePublicSubnetGateways(input, reporter, vpcID)
+	} else {
+		return nil
+	}
+}
+
+func (ac *awsCloud) preparePublicSubnetGateways(input api.PrepareForSubmarinerInput, reporter api.Reporter, vpcID string) error {
 	reporter.Started("Creating Submariner gateway security group")
 
 	gatewaySG, err := ac.createGatewaySG(vpcID, input.PublicPorts)


### PR DESCRIPTION
This will deploy no dedicated gateways or security groups.

Related-Issue: https://github.com/submariner-io/submariner/issues/1071
Fixes-Issue: #49

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
