### PR TITLE
Remove project-specific gitlint configuration

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,9 +1,0 @@
-[general]
-# body-is-missing: Allow commit messages with only a title
-# body-min-length: Allow short body lines, like "Relates-to: #issue"
-ignore=body-is-missing,body-min-length
-
-[ignore-by-body]
-# Dependabot doesn't follow our conventions, unfortunately
-regex=^Signed-off-by: dependabot\[bot\](.*)
-ignore=all


### PR DESCRIPTION
We now use Shipyard's gitlint configuration everywhere.

Depends on https://github.com/submariner-io/shipyard/pull/603
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
