### PR TITLE
Enable PR dependency check jobs

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,38 @@
+---
+name: PR Dependencies
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+  schedule:
+    - cron: '0 0/6 * * *' # every 6 hours
+
+jobs:
+  check:
+    name: Check Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@70a1b2d4ee1cdc743af33498bd0204123953a887
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # The label to use to mark dependent issues
+          label: dependent
+
+          # Enable checking for dependencies in issues.
+          check_issues: on
+
+          # A comma-separated list of keywords to mark dependency.
+          keywords: depends on, Depends on


### PR DESCRIPTION
This job marks a PR dependent whenever a dependent PR
is mentioned via Depends on/ depends on keyword.

The job fails until the dependent PR is not merged. This
helps in properly managing merging of dependent PRs.

Closes: #68

Signed-off-by: Janki Chhatbar jchhatba@redhat.com

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
