### PR TITLE
Don't run periodic PR dependency checks on forks

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   check:
     name: Check Dependencies
+    if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
     steps:
       - uses: z0al/dependent-issues@70a1b2d4ee1cdc743af33498bd0204123953a887


### PR DESCRIPTION
As we do with the Flake Finder and other periodic jobs, skip the checks
for PR dependencies on forks.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
