### PR TITLE
Delete egress rules for GCP

### DIFF
--- a/pkg/gcp/firewall_rules.go
+++ b/pkg/gcp/firewall_rules.go
@@ -27,20 +27,18 @@ import (
 
 const (
 	ingressDirection      = "INGRESS"
-	egressDirection       = "EGRESS"
 	publicPortsRuleName   = "submariner-public-ports"
 	internalPortsRuleName = "submariner-internal-ports"
 )
 
-func newExternalFirewallRules(projectID, infraID string, ports []api.PortSpec) (ingress, egress *compute.Firewall) {
-	ingressName, egressName := generateRuleNames(infraID, publicPortsRuleName)
+func newExternalFirewallRules(projectID, infraID string, ports []api.PortSpec) (ingress *compute.Firewall) {
+	ingressName := generateRuleName(infraID, publicPortsRuleName)
 
-	return newFirewallRule(projectID, infraID, ingressName, ingressDirection, ports),
-		newFirewallRule(projectID, infraID, egressName, egressDirection, ports)
+	return newFirewallRule(projectID, infraID, ingressName, ingressDirection, ports)
 }
 
 func newInternalFirewallRule(projectID, infraID string, ports []api.PortSpec) *compute.Firewall {
-	ingressName, _ := generateRuleNames(infraID, internalPortsRuleName)
+	ingressName := generateRuleName(infraID, internalPortsRuleName)
 
 	rule := newFirewallRule(projectID, infraID, ingressName, ingressDirection, ports)
 	rule.TargetTags = []string{
@@ -72,6 +70,6 @@ func newFirewallRule(projectID, infraID, name, direction string, ports []api.Por
 	}
 }
 
-func generateRuleNames(infraID, name string) (ingressName, egressName string) {
-	return fmt.Sprintf("%s-%s-ingress", infraID, name), fmt.Sprintf("%s-%s-egress", infraID, name)
+func generateRuleName(infraID, name string) (ingressName string) {
+	return fmt.Sprintf("%s-%s-ingress", infraID, name)
 }


### PR DESCRIPTION
Normally egress is always allowed by default, so we only
have to program ingress firewall rules for Submariner use-cases.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
