### PR TITLE
Revert to a r/w version of dependent-issues

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
     steps:
-      - uses: z0al/dependent-issues@ac8720898a3eb7118825148deae4cfaa9fe5924f
+      - uses: z0al/dependent-issues@1208b4dd978973b14de5b0b227a2871dbbf34ffb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Current versions of dependent-issues skip PRs opened by dependabot,
because GitHub now only provides readonly tokens for pull_request
actions triggered on dependabot PRs. However dependent-issues relies
on a pull_request_target event anyway, so it should still have a
read-write token.

This means that the “Dependent Issues” check stays in “Expected”
status; if we want to keep it as “Required” then we need some
workaround to be able to merge dependabot PRs.

This reverts to the last commit of dependent-issues before the change
to disable the check on dependabot PRs.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
