### PR TITLE
GCP support for deploying dedicated Gateway nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.40.27
+	github.com/pkg/errors v0.9.1
 	github.com/submariner-io/admiral v0.10.0-rc1.0.20210824123934-19b8fb8b93bc
 	google.golang.org/api v0.54.0
 	k8s.io/apimachinery v0.19.10

--- a/pkg/gcp/client/client.go
+++ b/pkg/gcp/client/client.go
@@ -92,30 +92,15 @@ func IsGCPNotFoundError(err error) bool {
 }
 
 func (g *gcpClient) GetInstance(zone, instance string) (*compute.Instance, error) {
-	resp, err := g.computeClient.Instances.Get(g.projectID, zone, instance).Context(context.TODO()).Do()
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return g.computeClient.Instances.Get(g.projectID, zone, instance).Context(context.TODO()).Do()
 }
 
 func (g *gcpClient) ListInstances(zone string) (*compute.InstanceList, error) {
-	resp, err := g.computeClient.Instances.List(g.projectID, zone).Context(context.TODO()).Do()
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return g.computeClient.Instances.List(g.projectID, zone).Context(context.TODO()).Do()
 }
 
 func (g *gcpClient) ListZones() (*compute.ZoneList, error) {
-	resp, err := g.computeClient.Zones.List(g.projectID).Context(context.TODO()).Do()
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return g.computeClient.Zones.List(g.projectID).Context(context.TODO()).Do()
 }
 
 func (g *gcpClient) InstanceHasPublicIP(instance *compute.Instance) (bool, error) {
@@ -124,11 +109,8 @@ func (g *gcpClient) InstanceHasPublicIP(instance *compute.Instance) (bool, error
 	}
 
 	networkInterface := instance.NetworkInterfaces[0]
-	if len(networkInterface.AccessConfigs) > 0 {
-		return true, nil
-	}
 
-	return false, nil
+	return len(networkInterface.AccessConfigs) > 0, nil
 }
 
 func (g *gcpClient) ConfigurePublicIPOnInstance(instance *compute.Instance) error {
@@ -144,13 +126,11 @@ func (g *gcpClient) ConfigurePublicIPOnInstance(instance *compute.Instance) erro
 		return nil
 	}
 
-	if _, err := g.computeClient.Instances.AddAccessConfig(
-		g.projectID, zone, instance.Name, networkInterface.Name, &compute.AccessConfig{}).
-		Context(context.TODO()).Do(); err != nil {
-		return err
-	}
+	_, err := g.computeClient.Instances.AddAccessConfig(g.projectID, zone, instance.Name,
+		networkInterface.Name, &compute.AccessConfig{}).
+		Context(context.TODO()).Do()
 
-	return nil
+	return err
 }
 
 func (g *gcpClient) DeletePublicIPOnInstance(instance *compute.Instance) error {
@@ -161,11 +141,9 @@ func (g *gcpClient) DeletePublicIPOnInstance(instance *compute.Instance) error {
 	// The zone of an instance is on URL, so we just need the latest value
 	zone := instance.Zone[strings.LastIndex(instance.Zone, "/")+1:]
 	networkInterface := instance.NetworkInterfaces[0]
-	if _, err := g.computeClient.Instances.DeleteAccessConfig(
+	_, err := g.computeClient.Instances.DeleteAccessConfig(
 		g.projectID, zone, instance.Name, "External NAT", networkInterface.Name).
-		Context(context.TODO()).Do(); err != nil {
-		return err
-	}
+		Context(context.TODO()).Do()
 
-	return nil
+	return err
 }

--- a/pkg/gcp/firewall_rules.go
+++ b/pkg/gcp/firewall_rules.go
@@ -26,15 +26,21 @@ import (
 )
 
 const (
-	ingressDirection      = "INGRESS"
-	publicPortsRuleName   = "submariner-public-ports"
-	internalPortsRuleName = "submariner-internal-ports"
+	ingressDirection         = "INGRESS"
+	publicPortsRuleName      = "submariner-public-ports"
+	internalPortsRuleName    = "submariner-internal-ports"
+	submarinerGatewayNodeTag = "submariner-io-gateway-node"
 )
 
 func newExternalFirewallRules(projectID, infraID string, ports []api.PortSpec) (ingress *compute.Firewall) {
 	ingressName := generateRuleName(infraID, publicPortsRuleName)
 
-	return newFirewallRule(projectID, infraID, ingressName, ingressDirection, ports)
+	ingressRule := newFirewallRule(projectID, infraID, ingressName, ingressDirection, ports)
+	ingressRule.TargetTags = []string{
+		submarinerGatewayNodeTag,
+	}
+
+	return ingressRule
 }
 
 func newInternalFirewallRule(projectID, infraID string, ports []api.PortSpec) *compute.Firewall {
@@ -55,11 +61,16 @@ func newInternalFirewallRule(projectID, infraID string, ports []api.PortSpec) *c
 
 func newFirewallRule(projectID, infraID, name, direction string, ports []api.PortSpec) *compute.Firewall {
 	allowedPorts := []*compute.FirewallAllowed{}
+
 	for _, port := range ports {
-		allowedPorts = append(allowedPorts, &compute.FirewallAllowed{
+		fwRule := &compute.FirewallAllowed{
 			IPProtocol: port.Protocol,
-			Ports:      []string{strconv.Itoa(int(port.Port))},
-		})
+		}
+		if port.Port != 0 {
+			fwRule.Ports = []string{strconv.Itoa(int(port.Port))}
+		}
+
+		allowedPorts = append(allowedPorts, fwRule)
 	}
 
 	return &compute.Firewall{

--- a/pkg/gcp/firewall_rules.go
+++ b/pkg/gcp/firewall_rules.go
@@ -35,6 +35,9 @@ const (
 func newExternalFirewallRules(projectID, infraID string, ports []api.PortSpec) (ingress *compute.Firewall) {
 	ingressName := generateRuleName(infraID, publicPortsRuleName)
 
+	// We want the external firewall rules to be applied only to Gateway nodes. So, we use the TargetTags
+	// field and include submarinerGatewayNodeTag for selection of Gateway nodes. All the Submariner Gateway
+	// instances will be tagged with submarinerGatewayNodeTag.
 	ingressRule := newFirewallRule(projectID, infraID, ingressName, ingressDirection, ports)
 	ingressRule.TargetTags = []string{
 		submarinerGatewayNodeTag,

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -29,18 +29,18 @@ import (
 )
 
 const (
-	messageRetrieveZones           = "Retrieving zones in the project"
-	messageRetrievedZones          = "Retrieved the zones"
-	messageValidateCurrentGWCount  = "Verifying if current gateways match the required number of gateways"
-	messageValidatedCurrentGWs     = "Current gateways match the required number of gateways"
-	messageDeployGatewayNode       = "Deploying gateway node"
-	messageDeployedGatewayNode     = "Successfully deployed gateway node"
-	messageDeployGatewayNodeFailed = "Could not deploy the required number of Gateway nodes"
-	messageCreateExtFWRules        = "Configuring the required firewall rules for inter-cluster traffic"
-	messageDeleteExtFWRules        = "Deleting the Submariner gateway firewall rules"
-	messageDeletedExtFWRules       = "Successfully deleted the firewall rules"
-	messageVerifyCurrentGWCount    = "Looking for current gateways in the project that need to be deleted"
-	messageVerifiedCurrentGWCount  = "Successfully deleted the gateway nodes"
+	messageRetrieveZones              = "Retrieving zones in the project"
+	messageRetrievedZones             = "Retrieved the zones"
+	messageValidateCurrentGWCount     = "Verifying if current gateways match the required number of gateways"
+	messageValidatedCurrentGWs        = "Current gateways match the required number of gateways"
+	messageDeployGatewayNode          = "Deploying gateway node"
+	messageDeployedGatewayNode        = "Successfully deployed gateway node"
+	messageInsufficientZonesForDeploy = "There are insufficient zone instances to deploy the required number of gateways"
+	messageCreateExtFWRules           = "Configuring the required firewall rules for inter-cluster traffic"
+	messageDeleteExtFWRules           = "Deleting the Submariner gateway firewall rules"
+	messageDeletedExtFWRules          = "Successfully deleted the firewall rules"
+	messageVerifyCurrentGWCount       = "Looking for current gateways in the project that need to be deleted"
+	messageVerifiedCurrentGWCount     = "Successfully deleted the gateway nodes"
 )
 
 type gcpCloud struct {

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -28,17 +28,33 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
+const (
+	messageRetrieveZones          = "Retrieving zones in the project"
+	messageRetrievedZones         = "Retrieved the zones"
+	messageValidateCurrentGWCount = "Verifying if current gateways match the required number of gateways"
+	messageValidatedCurrentGWs    = "Current gateways match the required number of gateways"
+	messageDeployGatewayNode      = "Deploying gateway node"
+	messageDeployedGatewayNode    = "Successfully deployed gateway node"
+	messageCreateExtFWRules       = "Configuring the required firewall rules for inter-cluster traffic"
+	messageDeleteExtFWRules       = "Deleting the Submariner gateway firewall rules"
+	messageDeletedExtFWRules      = "Successfully deleted the firewall rules"
+	messageVerifyCurrentGWCount   = "Looking for current gateways in the project that need to be deleted"
+	messageVerifiedCurrentGWCount = "Successfully deleted the gateway nodes"
+)
+
 type gcpCloud struct {
 	infraID   string
+	region    string
 	projectID string
 	client    gcpclient.Interface
 }
 
 // NewCloud creates a new api.Cloud instance which can prepare GCP for Submariner to be deployed on it
-func NewCloud(projectID, infraID string, client gcpclient.Interface) api.Cloud {
+func NewCloud(projectID, infraID, region string, client gcpclient.Interface) api.Cloud {
 	return &gcpCloud{
 		infraID:   infraID,
 		projectID: projectID,
+		region:    region,
 		client:    client,
 	}
 }

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -29,17 +29,18 @@ import (
 )
 
 const (
-	messageRetrieveZones          = "Retrieving zones in the project"
-	messageRetrievedZones         = "Retrieved the zones"
-	messageValidateCurrentGWCount = "Verifying if current gateways match the required number of gateways"
-	messageValidatedCurrentGWs    = "Current gateways match the required number of gateways"
-	messageDeployGatewayNode      = "Deploying gateway node"
-	messageDeployedGatewayNode    = "Successfully deployed gateway node"
-	messageCreateExtFWRules       = "Configuring the required firewall rules for inter-cluster traffic"
-	messageDeleteExtFWRules       = "Deleting the Submariner gateway firewall rules"
-	messageDeletedExtFWRules      = "Successfully deleted the firewall rules"
-	messageVerifyCurrentGWCount   = "Looking for current gateways in the project that need to be deleted"
-	messageVerifiedCurrentGWCount = "Successfully deleted the gateway nodes"
+	messageRetrieveZones           = "Retrieving zones in the project"
+	messageRetrievedZones          = "Retrieved the zones"
+	messageValidateCurrentGWCount  = "Verifying if current gateways match the required number of gateways"
+	messageValidatedCurrentGWs     = "Current gateways match the required number of gateways"
+	messageDeployGatewayNode       = "Deploying gateway node"
+	messageDeployedGatewayNode     = "Successfully deployed gateway node"
+	messageDeployGatewayNodeFailed = "Could not deploy the required number of Gateway nodes"
+	messageCreateExtFWRules        = "Configuring the required firewall rules for inter-cluster traffic"
+	messageDeleteExtFWRules        = "Deleting the Submariner gateway firewall rules"
+	messageDeletedExtFWRules       = "Successfully deleted the firewall rules"
+	messageVerifyCurrentGWCount    = "Looking for current gateways in the project that need to be deleted"
+	messageVerifiedCurrentGWCount  = "Successfully deleted the gateway nodes"
 )
 
 type gcpCloud struct {

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -35,7 +35,7 @@ const (
 	messageValidatedCurrentGWs        = "Current gateways match the required number of gateways"
 	messageDeployGatewayNode          = "Deploying gateway node"
 	messageDeployedGatewayNode        = "Successfully deployed gateway node"
-	messageInsufficientZonesForDeploy = "There are insufficient zone instances to deploy the required number of gateways"
+	messageInsufficientZonesForDeploy = "there are insufficient zone instances to deploy the required number of gateways"
 	messageCreateExtFWRules           = "Configuring the required firewall rules for inter-cluster traffic"
 	messageDeleteExtFWRules           = "Deleting the Submariner gateway firewall rules"
 	messageDeletedExtFWRules          = "Successfully deleted the firewall rules"

--- a/pkg/gcp/gw-machineset.go
+++ b/pkg/gcp/gw-machineset.go
@@ -1,0 +1,81 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package gcp
+
+var machineSetYAML = `apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: {{.InfraID}}
+  name: {{.InfraID}}-submariner-gw-{{.AZ}}
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: {{.InfraID}}
+      machine.openshift.io/cluster-api-machineset: {{.InfraID}}-submariner-gw-{{.AZ}}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        machine.openshift.io/cluster-api-cluster: {{.InfraID}}
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: {{.InfraID}}-submariner-gw-{{.AZ}}
+    spec:
+      metadata:
+        labels:
+          submariner.io/gateway: "true"
+      taints:
+        - effect: NoSchedule
+          key: node-role.submariner.io/gateway
+      providerSpec:
+        value:
+          apiVersion: gcpprovider.openshift.io/v1beta1
+          canIPForward: true
+          credentialsSecret:
+            name: gcp-cloud-credentials
+          deletionProtection: false
+          disks:
+          - autoDelete: true
+            boot: true
+            image: {{.Image}} 
+            labels: null
+            sizeGb: 128
+            type: pd-ssd
+          kind: GCPMachineProviderSpec
+          machineType: {{.InstanceType}}
+          metadata:
+            creationTimestamp: null
+          networkInterfaces:
+          - network: {{.InfraID}}-network
+            subnetwork: {{.InfraID}}-worker-subnet
+            publicIP: true
+          projectID: {{.ProjectID}}
+          region: {{.Region}}
+          serviceAccounts:
+          - email: {{.InfraID}}-w@{{.ProjectID}}.iam.gserviceaccount.com
+            scopes:
+            - https://www.googleapis.com/auth/cloud-platform
+          tags:
+          - {{.InfraID}}-worker
+          - {{.SubmarinerGWNodeTag}}
+          userDataSecret:
+            name: worker-user-data
+          zone: {{.AZ}}`

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -1,0 +1,285 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package gcp
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	"github.com/submariner-io/cloud-prepare/pkg/ocp"
+	"google.golang.org/api/compute/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+)
+
+type ocpGatewayDeployer struct {
+	gcp          *gcpCloud
+	msDeployer   ocp.MachineSetDeployer
+	instanceType string
+	image        string
+}
+
+// NewOcpGatewayDeployer returns a GatewayDeployer capable deploying gateways using OCP
+// If the supplied cloud is not a gcpCloud, an error is returned
+func NewOcpGatewayDeployer(cloud api.Cloud, msDeployer ocp.MachineSetDeployer, instanceType, image string) (api.GatewayDeployer, error) {
+	gcp, ok := cloud.(*gcpCloud)
+	if !ok {
+		return nil, errors.New("the cloud must be GCP")
+	}
+
+	return &ocpGatewayDeployer{
+		gcp:          gcp,
+		msDeployer:   msDeployer,
+		instanceType: instanceType,
+		image:        image,
+	}, nil
+}
+
+func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, reporter api.Reporter) error {
+	var currentGWInstanceList []*compute.Instance
+
+	reporter.Started(messageCreateExtFWRules)
+
+	externalIngress := newExternalFirewallRules(d.gcp.projectID, d.gcp.infraID, input.PublicPorts)
+	if err := d.gcp.openPorts(externalIngress); err != nil {
+		reporter.Failed(err)
+		return err
+	}
+
+	reporter.Succeeded("Opened External ports %q with firewall rule %q on GCP",
+		formatPorts(input.PublicPorts), externalIngress.Name)
+
+	reporter.Started(messageRetrieveZones)
+
+	zones, err := d.gcp.client.ListZones()
+	if err != nil {
+		reporter.Failed(err)
+		return fmt.Errorf("failed to list the zones in the project %q. %v", d.gcp.projectID, err)
+	}
+
+	reporter.Succeeded(messageRetrievedZones)
+
+	reporter.Started(messageValidateCurrentGWCount)
+
+	for _, zone := range zones.Items {
+		if zone.Region != d.gcp.region {
+			continue
+		}
+
+		instanceList, err := d.gcp.client.ListInstances(zone.Name)
+		if err != nil {
+			reporter.Failed(err)
+			return fmt.Errorf("failed to list instances in zone %q of project project %q. %v", zone.Name, d.gcp.projectID, err)
+		}
+
+		for _, instance := range instanceList.Items {
+			hasPublicIP, err := d.gcp.client.InstanceHasPublicIP(instance)
+			if err != nil {
+				reporter.Failed(err)
+				return fmt.Errorf("failed to verify if instance %q has public-ip or not in project %q. %v", instance.Name, d.gcp.projectID, err)
+			}
+
+			if hasPublicIP {
+				for _, tag := range instance.Tags.Items {
+					if tag == submarinerGatewayNodeTag {
+						currentGWInstanceList = append(currentGWInstanceList, instance)
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if len(currentGWInstanceList) == input.Gateways {
+		reporter.Succeeded(messageValidatedCurrentGWs)
+		return nil
+	}
+
+	if len(currentGWInstanceList) < input.Gateways {
+		gatewayNodesToDeploy := input.Gateways - len(currentGWInstanceList)
+
+		reporter.Started(messageDeployGatewayNode)
+
+		for _, zone := range zones.Items {
+			err := d.deployGateway(zone.Name)
+			if err != nil {
+				reporter.Failed(err)
+				return err
+			}
+
+			gatewayNodesToDeploy--
+			if gatewayNodesToDeploy <= 0 {
+				reporter.Succeeded(messageDeployedGatewayNode)
+				return nil
+			}
+		}
+	}
+
+	return nil
+}
+
+type machineSetConfig struct {
+	AZ                  string
+	InfraID             string
+	ProjectID           string
+	InstanceType        string
+	Region              string
+	Image               string
+	SubmarinerGWNodeTag string
+}
+
+func (d *ocpGatewayDeployer) loadGatewayYAML(zone, image string) ([]byte, error) {
+	var buf bytes.Buffer
+
+	// TODO: Not working properly, but we should revisit this as it makes more sense
+	// tpl, err := template.ParseFiles("pkg/aws/gw-machineset.yaml")
+	tpl, err := template.New("").Parse(machineSetYAML)
+	if err != nil {
+		return nil, err
+	}
+
+	tplVars := machineSetConfig{
+		AZ:                  zone,
+		InfraID:             d.gcp.infraID,
+		ProjectID:           d.gcp.projectID,
+		InstanceType:        d.instanceType,
+		Region:              d.gcp.region,
+		Image:               image,
+		SubmarinerGWNodeTag: submarinerGatewayNodeTag,
+	}
+
+	err = tpl.Execute(&buf, tplVars)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (d *ocpGatewayDeployer) initMachineSet(zone string) (*unstructured.Unstructured, error) {
+	gatewayYAML, err := d.loadGatewayYAML(zone, d.image)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructDecoder := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	machineSet := &unstructured.Unstructured{}
+	_, _, err = unstructDecoder.Decode(gatewayYAML, nil, machineSet)
+	if err != nil {
+		return nil, err
+	}
+
+	return machineSet, nil
+}
+
+func (d *ocpGatewayDeployer) deployGateway(zone string) error {
+	machineSet, err := d.initMachineSet(zone)
+	if err != nil {
+		return err
+	}
+
+	if d.image == "" {
+		d.image, err = d.msDeployer.GetWorkerNodeImage(machineSet, d.gcp.infraID)
+		if err != nil {
+			return err
+		}
+
+		machineSet, err = d.initMachineSet(zone)
+		if err != nil {
+			return err
+		}
+	}
+
+	return d.msDeployer.Deploy(machineSet)
+}
+
+func (d *ocpGatewayDeployer) Cleanup(reporter api.Reporter) error {
+	reporter.Started(messageDeleteExtFWRules)
+	err := d.deleteExternalFWRules(reporter)
+	if err != nil {
+		reporter.Failed(err)
+		return fmt.Errorf("failed to delete the gateway firewall rules in the project %q. %v", d.gcp.projectID, err)
+	}
+
+	reporter.Succeeded(messageDeletedExtFWRules)
+	reporter.Started(messageRetrieveZones)
+
+	zones, err := d.gcp.client.ListZones()
+	if err != nil {
+		reporter.Failed(err)
+		return fmt.Errorf("failed to list the zones in the project %q. %v", d.gcp.projectID, err)
+	}
+
+	reporter.Succeeded(messageRetrievedZones)
+	reporter.Started(messageVerifyCurrentGWCount)
+
+	for _, zone := range zones.Items {
+		region := zone.Region[strings.LastIndex(zone.Region, "/")+1:]
+		if region != d.gcp.region {
+			continue
+		}
+
+		instanceList, err := d.gcp.client.ListInstances(zone.Name)
+		if err != nil {
+			reporter.Failed(err)
+			return fmt.Errorf("failed to list instances in zone %q of project project %q. %v", zone.Name, d.gcp.projectID, err)
+		}
+
+		for _, instance := range instanceList.Items {
+			for _, tag := range instance.Tags.Items {
+				if tag == submarinerGatewayNodeTag {
+					err := d.deleteGateway(zone.Name)
+					if err != nil {
+						reporter.Failed(err)
+						return fmt.Errorf("failed to delete gateway instance %q. %v", instance.Name, err)
+					}
+
+					break
+				}
+			}
+		}
+	}
+
+	reporter.Succeeded(messageVerifiedCurrentGWCount)
+
+	return nil
+}
+
+func (d *ocpGatewayDeployer) deleteGateway(zone string) error {
+	machineSet, err := d.initMachineSet(zone)
+	if err != nil {
+		return err
+	}
+
+	return d.msDeployer.Delete(machineSet)
+}
+
+func (d *ocpGatewayDeployer) deleteExternalFWRules(reporter api.Reporter) error {
+	ingressName := generateRuleName(d.gcp.infraID, publicPortsRuleName)
+
+	if err := d.gcp.deleteFirewallRule(ingressName, reporter); err != nil {
+		reporter.Failed(err)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR implements the following
1. Supports deploying new Gateway nodes using the OCP machineset API
2. Cleanup of any existing gateway nodes and firewall rules
3. Fixes the public-firewall-rules to be applied only to gateway nodes

Fixes issue: https://github.com/submariner-io/cloud-prepare/issues/91
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
