### PR TITLE
GCP support for configuring existing worker nodes as gw nodes

### DIFF
--- a/pkg/gcp/client/client.go
+++ b/pkg/gcp/client/client.go
@@ -40,6 +40,7 @@ type Interface interface {
 	ListInstances(zone string) (*compute.InstanceList, error)
 	ListZones() (*compute.ZoneList, error)
 	InstanceHasPublicIP(instance *compute.Instance) (bool, error)
+	UpdateInstanceNetworkTags(project, zone, instance string, tags *compute.Tags) error
 	ConfigurePublicIPOnInstance(instance *compute.Instance) error
 	DeletePublicIPOnInstance(instance *compute.Instance) error
 }
@@ -111,6 +112,12 @@ func (g *gcpClient) InstanceHasPublicIP(instance *compute.Instance) (bool, error
 	networkInterface := instance.NetworkInterfaces[0]
 
 	return len(networkInterface.AccessConfigs) > 0, nil
+}
+
+func (g *gcpClient) UpdateInstanceNetworkTags(project, zone, instance string, tags *compute.Tags) error {
+	_, err := g.computeClient.Instances.SetTags(project, zone, instance, tags).Context(context.TODO()).Do()
+
+	return err
 }
 
 func (g *gcpClient) ConfigurePublicIPOnInstance(instance *compute.Instance) error {

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -36,7 +36,7 @@ const (
 	messageDeployedGatewayNode        = "Successfully deployed gateway node"
 	messageInsufficientZonesForDeploy = "there are insufficient zone instances to deploy the required number of gateways"
 	messageCreateExtFWRules           = "Configuring the required firewall rules for inter-cluster traffic"
-	messageDeleteExtFWRules           = "Retrieving the Submariner gateway firewall rules"
+	messageRetrieveExtFWRules         = "Retrieving the Submariner gateway firewall rules"
 	messageDeletedExtFWRules          = "Successfully deleted the firewall rules"
 )
 

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -33,14 +33,11 @@ const (
 	messageRetrievedZones             = "Retrieved the zones"
 	messageValidateCurrentGWCount     = "Verifying if current gateways match the required number of gateways"
 	messageValidatedCurrentGWs        = "Current gateways match the required number of gateways"
-	messageDeployGatewayNode          = "Deploying gateway node"
 	messageDeployedGatewayNode        = "Successfully deployed gateway node"
 	messageInsufficientZonesForDeploy = "there are insufficient zone instances to deploy the required number of gateways"
 	messageCreateExtFWRules           = "Configuring the required firewall rules for inter-cluster traffic"
-	messageDeleteExtFWRules           = "Deleting the Submariner gateway firewall rules"
+	messageDeleteExtFWRules           = "Retrieving the Submariner gateway firewall rules"
 	messageDeletedExtFWRules          = "Successfully deleted the firewall rules"
-	messageVerifyCurrentGWCount       = "Looking for current gateways in the project that need to be deleted"
-	messageVerifiedCurrentGWCount     = "Successfully deleted the gateway nodes"
 )
 
 type gcpCloud struct {

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -304,7 +304,7 @@ func (d *ocpGatewayDeployer) configureExistingNodeAsGW(zone, gcpInstanceInfo, no
 }
 
 func (d *ocpGatewayDeployer) Cleanup(reporter api.Reporter) error {
-	reporter.Started(messageDeleteExtFWRules)
+	reporter.Started(messageRetrieveExtFWRules)
 	err := d.deleteExternalFWRules(reporter)
 	if err != nil {
 		return reportFailure(reporter, err, "failed to delete the gateway firewall rules in the project %q", d.gcp.projectID)
@@ -339,7 +339,7 @@ func (d *ocpGatewayDeployer) Cleanup(reporter api.Reporter) error {
 			// the gateway node was deployed using the OCPMachineSet API otherwise it's an existing worker node.
 			prefix := d.gcp.infraID + "-submariner-gw-" + zone.Name
 			if strings.HasPrefix(instance.Name, prefix) {
-				reporter.Started(fmt.Sprintf("Deleting the Gateway instance %q", instance.Name))
+				reporter.Started(fmt.Sprintf("Deleting the gateway instance %q", instance.Name))
 				err := d.deleteGateway(zone.Name)
 				if err != nil {
 					return reportFailure(reporter, err, "failed to delete dedicated gateway instance %q", instance.Name)
@@ -347,7 +347,7 @@ func (d *ocpGatewayDeployer) Cleanup(reporter api.Reporter) error {
 
 				reporter.Succeeded("Successfully deleted the instance")
 			} else {
-				reporter.Started(fmt.Sprintf("Removing the Gateway configuration from instance %q", instance.Name))
+				reporter.Started(fmt.Sprintf("Removing the gateway configuration from instance %q", instance.Name))
 				err = d.resetExistingGWNode(zone.Name, instance)
 				if err != nil {
 					return reportFailure(reporter, err, "failed to delete gateway instance %q", instance.Name)
@@ -358,7 +358,7 @@ func (d *ocpGatewayDeployer) Cleanup(reporter api.Reporter) error {
 		}
 	}
 
-	reporter.Started("Removing the Submariner Gateway labels from K8s nodes")
+	reporter.Started("Removing the Submariner gateway labels from K8s nodes")
 
 	err = d.k8sClient.RemoveGWLabelFromWorkerNodes()
 	if err != nil {

--- a/pkg/k8s/k8siface.go
+++ b/pkg/k8s/k8siface.go
@@ -1,0 +1,117 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	submarinerGatewayLabel = "submariner.io/gateway"
+)
+
+type K8sInterface interface {
+	ListWorkerNodes(labelSelector string) (*v1.NodeList, error)
+	AddGWLabelOnNode(nodeName string) error
+	RemoveGWLabelFromWorkerNodes() error
+}
+
+type k8sIface struct {
+	clientSet *kubernetes.Clientset
+}
+
+func NewK8sInterface(k8sConfig *rest.Config) (K8sInterface, error) {
+	k8sClient, err := kubernetes.NewForConfig(k8sConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &k8sIface{clientSet: k8sClient}, nil
+}
+
+func (k *k8sIface) ListWorkerNodes(labelSelector string) (*v1.NodeList, error) {
+	nodes, err := k.clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list the nodes in the cluster, err: %s", err)
+	}
+
+	return nodes, nil
+}
+
+func (k *k8sIface) AddGWLabelOnNode(nodeName string) error {
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := k.clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to get node info for node %v, err: %s", nodeName, err)
+		}
+
+		labels := node.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[submarinerGatewayLabel] = "true"
+		node.SetLabels(labels)
+		_, updateErr := k.clientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+		return updateErr
+	})
+
+	if retryErr != nil {
+		return fmt.Errorf("error updatating node %q, err: %s", nodeName, retryErr)
+	}
+
+	return nil
+}
+
+func (k *k8sIface) RemoveGWLabelFromWorkerNodes() error {
+	nodeList, err := k.clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker"})
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodeList.Items {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			node, err := k.clientSet.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to get node info for node %v, err: %s", node.Name, err)
+			}
+
+			labels := node.GetLabels()
+			if labels == nil {
+				return nil
+			}
+			delete(labels, submarinerGatewayLabel)
+			node.SetLabels(labels)
+			_, updateErr := k.clientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+			return updateErr
+		})
+
+		if retryErr != nil {
+			return fmt.Errorf("error updatating node %q, err: %s", node.Name, retryErr)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR implements the necessary functionality to configure the
existing worker nodes of OCP cluster as Submariner Gateway nodes.
In this process, it mainly does the following.
1. Identifies worker nodes per zone and labels them with submariner
   gateway label.
2. Configures public-ip on the respective instance
3. Modifies the GCP instance NetworkTag to include the label used
   for external firewall configuration.

Fixes issue: https://github.com/submariner-io/cloud-prepare/issues/97
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
