### PR TITLE
Check infraID while listing the cluster instances

### DIFF
--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -178,6 +178,11 @@ func (d *ocpGatewayDeployer) parseCurrentGatewayInstances(reporter api.Reporter)
 		}
 
 		for _, instance := range instanceList.Items {
+			// Check if the instance belongs to the cluster (identified via infraID) we are operating on.
+			if !strings.HasPrefix(instance.Name, d.gcp.infraID) {
+				continue
+			}
+
 			// A GatewayNode will always be tagged with submarinerGatewayNodeTag when deployed with OCPMachineSet
 			// as well as when an existing worker node is updated as a Gateway node.
 			if d.isInstanceGatewayNode(instance) {
@@ -324,6 +329,11 @@ func (d *ocpGatewayDeployer) Cleanup(reporter api.Reporter) error {
 		}
 
 		for _, instance := range instanceList.Items {
+			// Check if the instance belongs to the cluster (identified via infraID) we are operating on.
+			if !strings.HasPrefix(instance.Name, d.gcp.infraID) {
+				continue
+			}
+
 			if !d.isInstanceGatewayNode(instance) {
 				continue
 			}


### PR DESCRIPTION
A GCP user can install multiple clusters in the same region.
In such situations, along with checking for the region we should
also check the infraID to identify the instances that belong
to the cluster we are operating on. This PR includes the missing
check.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
