### PR TITLE
Pass clientset instead of restConfig

### DIFF
--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-	"k8s.io/client-go/rest"
 )
 
 type ocpGatewayDeployer struct {
@@ -46,15 +45,10 @@ type ocpGatewayDeployer struct {
 // NewOcpGatewayDeployer returns a GatewayDeployer capable deploying gateways using OCP
 // If the supplied cloud is not a gcpCloud, an error is returned
 func NewOcpGatewayDeployer(cloud api.Cloud, msDeployer ocp.MachineSetDeployer, instanceType, image string,
-	dedicatedGWNode bool, k8sConfig *rest.Config) (api.GatewayDeployer, error) {
+	dedicatedGWNode bool, k8sClient k8s.K8sInterface) (api.GatewayDeployer, error) {
 	gcp, ok := cloud.(*gcpCloud)
 	if !ok {
 		return nil, errors.New("the cloud must be GCP")
-	}
-
-	k8sClient, err := k8s.NewK8sInterface(k8sConfig)
-	if err != nil {
-		return nil, errors.Errorf("error creating the k8s clientSet %v", err)
 	}
 
 	return &ocpGatewayDeployer{

--- a/pkg/k8s/k8siface.go
+++ b/pkg/k8s/k8siface.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -40,16 +39,11 @@ type K8sInterface interface {
 }
 
 type k8sIface struct {
-	clientSet *kubernetes.Clientset
+	clientSet kubernetes.Interface
 }
 
-func NewK8sInterface(k8sConfig *rest.Config) (K8sInterface, error) {
-	k8sClient, err := kubernetes.NewForConfig(k8sConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return &k8sIface{clientSet: k8sClient}, nil
+func NewK8sInterface(clientSet kubernetes.Interface) (K8sInterface, error) {
+	return &k8sIface{clientSet: clientSet}, nil
 }
 
 func (k *k8sIface) ListWorkerNodes(labelSelector string) (*v1.NodeList, error) {


### PR DESCRIPTION
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
