### PR TITLE
Avoid specifying null creation timestamps

### DIFF
--- a/pkg/aws/gw-machineset.go
+++ b/pkg/aws/gw-machineset.go
@@ -32,7 +32,6 @@ spec:
       machine.openshift.io/cluster-api-machineset: {{.InfraID}}-submariner-gw-{{.AZ}}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         machine.openshift.io/cluster-api-cluster: {{.InfraID}}
         machine.openshift.io/cluster-api-machine-role: worker

--- a/pkg/aws/gw-machineset.yaml.template
+++ b/pkg/aws/gw-machineset.yaml.template
@@ -14,7 +14,6 @@ spec:
       machine.openshift.io/cluster-api-machineset: {{.InfraID}}-submariner-gw-{{.AZ}}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         machine.openshift.io/cluster-api-cluster: {{.InfraID}}
         machine.openshift.io/cluster-api-machine-role: worker

--- a/pkg/gcp/gw-machineset.go
+++ b/pkg/gcp/gw-machineset.go
@@ -32,7 +32,6 @@ spec:
       machine.openshift.io/cluster-api-machineset: {{.InfraID}}-submariner-gw-{{.AZ}}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         machine.openshift.io/cluster-api-cluster: {{.InfraID}}
         machine.openshift.io/cluster-api-machine-role: worker
@@ -62,7 +61,6 @@ spec:
           kind: GCPMachineProviderSpec
           machineType: {{.InstanceType}}
           metadata:
-            creationTimestamp: null
           networkInterfaces:
           - network: {{.InfraID}}-network
             subnetwork: {{.InfraID}}-worker-subnet


### PR DESCRIPTION
These are preserved as-is in created resources, and cause errors when
editing the resources later on.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
