### PR TITLE
Add packagedoc-lint linting, fix errors

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -84,6 +84,15 @@ jobs:
       - name: Run markdownlint
         run: make markdownlint
 
+  packagedoc-lint:
+    name: Package Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Run packagedoc-lint
+        run: make packagedoc-lint
+
   yaml-lint:
     name: YAML
     runs-on: ubuntu-latest

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package api
 
 // Reporter is responsible for reporting back on the progress of the cloud preparation.

--- a/pkg/api/logging_reporter.go
+++ b/pkg/api/logging_reporter.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package api
 
 import (

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package aws
 
 import (

--- a/pkg/aws/ec2helpers.go
+++ b/pkg/aws/ec2helpers.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package aws
 
 import (

--- a/pkg/aws/errors.go
+++ b/pkg/aws/errors.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package aws
 
 import (

--- a/pkg/aws/gw-machineset.go
+++ b/pkg/aws/gw-machineset.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package aws
 
 var machineSetYAML = `apiVersion: machine.openshift.io/v1beta1

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package aws
 
 import (

--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package aws
 
 import (

--- a/pkg/aws/subnets.go
+++ b/pkg/aws/subnets.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package aws
 
 import (

--- a/pkg/aws/validations.go
+++ b/pkg/aws/validations.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package aws
 
 import (

--- a/pkg/aws/vpcs.go
+++ b/pkg/aws/vpcs.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package aws
 
 import (

--- a/pkg/gcp/cloud_info.go
+++ b/pkg/gcp/cloud_info.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gcp
 
 import (

--- a/pkg/gcp/firewall_rules.go
+++ b/pkg/gcp/firewall_rules.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gcp
 
 import (

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gcp
 
 import (

--- a/pkg/gcp/gcp_cloud_test.go
+++ b/pkg/gcp/gcp_cloud_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gcp_test
 
 import (

--- a/pkg/gcp/gcp_suite_test.go
+++ b/pkg/gcp/gcp_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gcp_test
 
 import (

--- a/pkg/gcp/gw-machineset.go
+++ b/pkg/gcp/gw-machineset.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gcp
 
 var machineSetYAML = `apiVersion: machine.openshift.io/v1beta1

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gcp
 
 import (

--- a/pkg/rhos/gw-machineset.go
+++ b/pkg/rhos/gw-machineset.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rhos
 
 var machineSetYAML = `apiVersion: machine.openshift.io/v1beta1

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rhos
 
 import (

--- a/pkg/rhos/rhos.go
+++ b/pkg/rhos/rhos.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rhos
 
 import (

--- a/pkg/rhos/securitygroups.go
+++ b/pkg/rhos/securitygroups.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rhos
 
 import (


### PR DESCRIPTION
The idea here is to make sure the license headers are detached from the
package declarations, as otherwise the headers are considered a part of
the package documentation and included with it.

Add per-PR job to maintain consistent standards across all repos.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>
(cherry picked from commit 7c22542dc014739fe5dfee2131e1fcc62fc4f364)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
