### PR TITLE
Wrap parameter/return lists as expected by gofumpt

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -61,57 +61,68 @@ type awsClient struct {
 }
 
 func (ac *awsClient) AuthorizeSecurityGroupIngress(ctx context.Context, input *ec2.AuthorizeSecurityGroupIngressInput,
-	optFns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
 	return ac.ec2Client.AuthorizeSecurityGroupIngress(ctx, input, optFns...)
 }
 
 func (ac *awsClient) CreateSecurityGroup(ctx context.Context, input *ec2.CreateSecurityGroupInput,
-	optFns ...func(*ec2.Options)) (*ec2.CreateSecurityGroupOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.CreateSecurityGroupOutput, error) {
 	return ac.ec2Client.CreateSecurityGroup(ctx, input, optFns...)
 }
 
 func (ac *awsClient) CreateTags(ctx context.Context, input *ec2.CreateTagsInput,
-	optFns ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.CreateTagsOutput, error) {
 	return ac.ec2Client.CreateTags(ctx, input, optFns...)
 }
 
 func (ac *awsClient) DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput,
-	optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.DescribeInstancesOutput, error) {
 	return ac.ec2Client.DescribeInstances(ctx, input, optFns...)
 }
 
 func (ac *awsClient) DescribeVpcs(ctx context.Context, input *ec2.DescribeVpcsInput,
-	optFns ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.DescribeVpcsOutput, error) {
 	return ac.ec2Client.DescribeVpcs(ctx, input, optFns...)
 }
 
 func (ac *awsClient) DescribeSecurityGroups(ctx context.Context, input *ec2.DescribeSecurityGroupsInput,
-	optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.DescribeSecurityGroupsOutput, error) {
 	return ac.ec2Client.DescribeSecurityGroups(ctx, input, optFns...)
 }
 
 func (ac *awsClient) DescribeSubnets(ctx context.Context, input *ec2.DescribeSubnetsInput,
-	optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.DescribeSubnetsOutput, error) {
 	return ac.ec2Client.DescribeSubnets(ctx, input, optFns...)
 }
 
 func (ac *awsClient) DeleteSecurityGroup(ctx context.Context, input *ec2.DeleteSecurityGroupInput,
-	optFns ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.DeleteSecurityGroupOutput, error) {
 	return ac.ec2Client.DeleteSecurityGroup(ctx, input, optFns...)
 }
 
 func (ac *awsClient) DeleteTags(ctx context.Context, input *ec2.DeleteTagsInput,
-	optFns ...func(*ec2.Options)) (*ec2.DeleteTagsOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.DeleteTagsOutput, error) {
 	return ac.ec2Client.DeleteTags(ctx, input, optFns...)
 }
 
 func (ac *awsClient) RevokeSecurityGroupIngress(ctx context.Context, input *ec2.RevokeSecurityGroupIngressInput,
-	optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.RevokeSecurityGroupIngressOutput, error) {
 	return ac.ec2Client.RevokeSecurityGroupIngress(ctx, input, optFns...)
 }
 
 func (ac *awsClient) DescribeInstanceTypeOfferings(ctx context.Context, input *ec2.DescribeInstanceTypeOfferingsInput,
-	optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
+	optFns ...func(*ec2.Options),
+) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
 	return ac.ec2Client.DescribeInstanceTypeOfferings(ctx, input, optFns...)
 }
 

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -143,7 +143,8 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 }
 
 func (d *ocpGatewayDeployer) validateDeployPrerequisites(vpcID string, input api.GatewayDeployInput,
-	publicSubnets []types.Subnet) error {
+	publicSubnets []types.Subnet,
+) error {
 	var errs []error
 	var subnets []types.Subnet
 

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -46,7 +46,8 @@ type ocpGatewayDeployer struct {
 
 // NewOcpGatewayDeployer returns a GatewayDeployer capable of deploying gateways using OCP.
 func NewOcpGatewayDeployer(info CloudInfo, msDeployer ocp.MachineSetDeployer, instanceType, image string,
-	dedicatedGWNode bool, k8sClient k8s.Interface) api.GatewayDeployer {
+	dedicatedGWNode bool, k8sClient k8s.Interface,
+) api.GatewayDeployer {
 	return &ocpGatewayDeployer{
 		CloudInfo:       info,
 		msDeployer:      msDeployer,

--- a/pkg/ocp/machinesets.go
+++ b/pkg/ocp/machinesets.go
@@ -70,7 +70,8 @@ func (msd *k8sMachineSetDeployer) clientFor(obj runtime.Object) (dynamic.Resourc
 }
 
 func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(workerNodeList []string, machineSet *unstructured.Unstructured,
-	infraID string) (string, error) {
+	infraID string,
+) (string, error) {
 	machineSetClient, err := msd.clientFor(machineSet)
 	if err != nil {
 		return "", err

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -48,7 +48,8 @@ type ocpGatewayDeployer struct {
 
 // NewOcpGatewayDeployer returns a GatewayDeployer capable of deploying gateways using OCP.
 func NewOcpGatewayDeployer(info CloudInfo, msDeployer ocp.MachineSetDeployer, projectID, instanceType, image, cloudName string,
-	dedicatedGWNode bool) api.GatewayDeployer {
+	dedicatedGWNode bool,
+) api.GatewayDeployer {
 	return &ocpGatewayDeployer{
 		CloudInfo:       info,
 		projectID:       projectID,
@@ -168,7 +169,8 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 }
 
 func (d *ocpGatewayDeployer) deployGWNode(gwNodes *v1.NodeList, gatewayCount int, groupName string,
-	computeClient *gophercloud.ServiceClient, status reporter.Interface) error {
+	computeClient *gophercloud.ServiceClient, status reporter.Interface,
+) error {
 	numGatewayNodes := len(gwNodes.Items)
 
 	if numGatewayNodes == gatewayCount {
@@ -212,7 +214,8 @@ func (d *ocpGatewayDeployer) deployDedicatedGWNode(gatewayNodesToDeploy int, sta
 }
 
 func (d *ocpGatewayDeployer) tagExistingNode(groupName string, computeClient *gophercloud.ServiceClient,
-	gatewayNodesToDeploy int, status reporter.Interface) error {
+	gatewayNodesToDeploy int, status reporter.Interface,
+) error {
 	workerNodes, err := d.K8sClient.ListNodesWithLabel("node-role.kubernetes.io/worker")
 	if err != nil {
 		return status.Error(err, "failed to list k8s nodes in project %q", d.projectID)

--- a/pkg/rhos/securitygroups.go
+++ b/pkg/rhos/securitygroups.go
@@ -37,7 +37,8 @@ type CloudInfo struct {
 }
 
 func (c *CloudInfo) openInternalPorts(infraID string, ports []api.PortSpec,
-	computeClient, networkClient *gophercloud.ServiceClient) error {
+	computeClient, networkClient *gophercloud.ServiceClient,
+) error {
 	groupName := infraID + internalSecurityGroupSuffix
 	opts := secgroups.CreateOpts{
 		Name:        groupName,
@@ -85,7 +86,8 @@ func (c *CloudInfo) openInternalPorts(infraID string, ports []api.PortSpec,
 }
 
 func (c *CloudInfo) removeInternalFirewallRules(infraID string,
-	computeClient *gophercloud.ServiceClient) error {
+	computeClient *gophercloud.ServiceClient,
+) error {
 	groupName := infraID + internalSecurityGroupSuffix
 
 	pager := servers.List(computeClient, servers.ListOpts{Name: c.InfraID})
@@ -115,7 +117,8 @@ func (c *CloudInfo) removeInternalFirewallRules(infraID string,
 }
 
 func (c *CloudInfo) createGWSecurityGroup(ports []api.PortSpec, groupName string, computeClient *gophercloud.ServiceClient,
-	networkClient *gophercloud.ServiceClient) error {
+	networkClient *gophercloud.ServiceClient,
+) error {
 	isFound, err := checkIfSecurityGroupPresent(groupName, computeClient)
 	if err != nil {
 		return err
@@ -242,7 +245,8 @@ func (c *CloudInfo) deleteSG(groupName string, computeClient *gophercloud.Servic
 }
 
 func (c *CloudInfo) createSGRule(group, remoteGroupID, remoteIPPrefix string, port uint16,
-	protocol string, networkClient *gophercloud.ServiceClient) error {
+	protocol string, networkClient *gophercloud.ServiceClient,
+) error {
 	opts := rules.CreateOpts{
 		Direction:      "ingress",
 		EtherType:      rules.EtherType4,


### PR DESCRIPTION
This is required by golangci-lint 1.45.2; it all involves formatting
wrapped lists of parameters or return types.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
