### PR TITLE
Automated backport of #256: Bump markdown-link-check to the current tip

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Run markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@9710f0fec812ce0a3b98bef4c9d842fc1f39d976
+        uses: gaurav-nelson/github-action-markdown-link-check@228fbf4ffb2a86a65314866e9b2322b519fd885f
         with:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"


### PR DESCRIPTION
Backport of #256 on release-0.12.

#256: Bump markdown-link-check to the current tip

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.