### PR TITLE
Add support to tag existing node as g/w node

### DIFF
--- a/pkg/azure/cloud_info.go
+++ b/pkg/azure/cloud_info.go
@@ -146,10 +146,11 @@ func (c *CloudInfo) createSecurityRule(securityRulePrfix, protocol string, port 
 	}
 }
 
-func (c *CloudInfo) createGWSecurityGroup(infraID string, ports []api.PortSpec, sgClient *network.SecurityGroupsClient) error {
-	groupName := infraID + externalSecurityGroupSuffix
+func (c *CloudInfo) createGWSecurityGroup(groupName string, ports []api.PortSpec, sgClient *network.SecurityGroupsClient) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer cancel()
 
-	isFound := checkIfSecurityGroupPresent(groupName, sgClient, c.BaseGroupName)
+	isFound := checkIfSecurityGroupPresent(ctx, groupName, sgClient, c.BaseGroupName)
 	if isFound {
 		return nil
 	}
@@ -170,9 +171,6 @@ func (c *CloudInfo) createGWSecurityGroup(infraID string, ports []api.PortSpec, 
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
-
 	future, err := sgClient.CreateOrUpdate(ctx, c.BaseGroupName, groupName, nwSecurityGroup)
 	if err != nil {
 		return errors.Wrapf(err, "creating security group %q failed", groupName)
@@ -183,18 +181,33 @@ func (c *CloudInfo) createGWSecurityGroup(infraID string, ports []api.PortSpec, 
 	return errors.Wrapf(err, "Error creating  security group %v ", groupName)
 }
 
-// TODO Make this private once gwdeployer is done
-
-func (c *CloudInfo) openGWSecurityGroup(interfaceName, groupName string, sgClient *network.SecurityGroupsClient,
-	nwClient *network.InterfacesClient,
+func (c *CloudInfo) prepareGWInterface(nodeName, groupName string, nsgClient *network.SecurityGroupsClient,
+	nwClient *network.InterfacesClient, pubIPClient *network.PublicIPAddressesClient,
 ) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 
-	nwSecurityGroup, err := sgClient.Get(ctx, c.BaseGroupName, groupName, "")
+	nwSecurityGroup, err := nsgClient.Get(ctx, c.BaseGroupName, groupName, "")
 	if err != nil {
 		return errors.Wrapf(err, "error getting the submariner gateway security group %q", groupName)
 	}
+
+	publicIPName := nodeName + "-pub"
+
+	var pubIP network.PublicIPAddress
+
+	pubIP, err = getPublicIP(ctx, publicIPName, pubIPClient, c.BaseGroupName)
+
+	if err != nil {
+		var err error
+
+		pubIP, err = c.CreatePublicIP(ctx, publicIPName, pubIPClient)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create public IP %q", publicIPName)
+		}
+	}
+
+	interfaceName := nodeName + "-nic"
 
 	nwInterface, err := nwClient.Get(ctx, c.BaseGroupName, interfaceName, "")
 	if err != nil {
@@ -203,32 +216,41 @@ func (c *CloudInfo) openGWSecurityGroup(interfaceName, groupName string, sgClien
 
 	nwInterface.InterfacePropertiesFormat.NetworkSecurityGroup = &nwSecurityGroup
 
+	nwInterfaceIPConfiguration := *nwInterface.InterfacePropertiesFormat.IPConfigurations
+	for i := range nwInterfaceIPConfiguration {
+		if nwInterfaceIPConfiguration[i].Primary != nil && *nwInterfaceIPConfiguration[i].Primary {
+			nwInterfaceIPConfiguration[i].PublicIPAddress = &pubIP
+			break
+		}
+	}
+
 	future, err := nwClient.CreateOrUpdate(ctx, c.BaseGroupName, *nwInterface.Name, nwInterface)
 	if err != nil {
-		return errors.Wrapf(err, "adding  security group %q to interface %q failed", groupName,
-			*nwInterface.ID)
+		return errors.Wrapf(err, "adding security group %q and public IP %q to interface %q failed", *nwSecurityGroup.Name,
+			*pubIP.Name, *nwInterface.ID)
 	}
 
-	err = future.WaitForCompletionRef(ctx, sgClient.Client)
+	err = future.WaitForCompletionRef(ctx, nwClient.Client)
 	if err != nil {
-		return errors.Wrapf(err, "updating  interface  %q failed", *nwInterface.Name)
+		return errors.Wrapf(err, "updating interface %q failed", *nwInterface.Name)
 	}
 
-	return errors.Wrapf(err, "waiting for the submariner gateway security group  %q to be updated failed", groupName)
+	return errors.Wrapf(err, "waiting for the g/w interface %q to be updated failed", interfaceName)
 }
 
-func (c *CloudInfo) removeGWSecurityGroup(infraID string, sgClient *network.SecurityGroupsClient,
+func (c *CloudInfo) cleanupGWInterface(infraID string, sgClient *network.SecurityGroupsClient,
 	nwClient *network.InterfacesClient,
 ) error {
 	groupName := infraID + externalSecurityGroupSuffix
-	isFound := checkIfSecurityGroupPresent(groupName, sgClient, c.BaseGroupName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer cancel()
+
+	isFound := checkIfSecurityGroupPresent(ctx, groupName, sgClient, c.BaseGroupName)
 
 	if !isFound {
 		return nil
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	nwSecurityGroup, err := sgClient.Get(ctx, c.BaseGroupName, groupName, "")
 	if err != nil {
@@ -254,6 +276,9 @@ func (c *CloudInfo) removeGWSecurityGroup(infraID string, sgClient *network.Secu
 			}
 
 			interfaceWithSG.InterfacePropertiesFormat.NetworkSecurityGroup = nil
+			if interfaceWithSG.InterfacePropertiesFormat.IPConfigurations != nil {
+				removePublicIP(*interfaceWithSG.InterfacePropertiesFormat.IPConfigurations)
+			}
 
 			future, err := nwClient.CreateOrUpdate(ctx, c.BaseGroupName, *interfaceWithSG.Name, interfaceWithSG)
 			if err != nil {
@@ -286,11 +311,73 @@ func (c *CloudInfo) removeGWSecurityGroup(infraID string, sgClient *network.Secu
 	return errors.WithMessage(err, "failed to remove the submariner gateway security group from servers")
 }
 
-func checkIfSecurityGroupPresent(groupName string, networkClient *network.SecurityGroupsClient, baseGroupName string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
+func removePublicIP(nwInterfaceIPConfiguration []network.InterfaceIPConfiguration) {
+	for i := range nwInterfaceIPConfiguration {
+		if nwInterfaceIPConfiguration[i].Primary != nil && *nwInterfaceIPConfiguration[i].Primary {
+			nwInterfaceIPConfiguration[i].PublicIPAddress = nil
+			break
+		}
+	}
+}
 
+func checkIfSecurityGroupPresent(ctx context.Context, groupName string, networkClient *network.SecurityGroupsClient,
+	baseGroupName string,
+) bool {
 	_, err := networkClient.Get(ctx, baseGroupName, groupName, "")
 
 	return err == nil
+}
+
+func getPublicIP(ctx context.Context, publicIPName string, pubIPClient *network.PublicIPAddressesClient, baseGroupName string,
+) (network.PublicIPAddress, error) {
+	publicIP, err := pubIPClient.Get(ctx, baseGroupName, publicIPName, "")
+
+	return publicIP, errors.Wrapf(err, "error getting public ip: %q", publicIPName)
+}
+
+func (c *CloudInfo) CreatePublicIP(ctx context.Context, ipName string, ipClient *network.PublicIPAddressesClient,
+) (ip network.PublicIPAddress, err error) {
+	future, err := ipClient.CreateOrUpdate(
+		ctx,
+		c.BaseGroupName,
+		ipName,
+		network.PublicIPAddress{
+			Name: to.StringPtr(ipName),
+			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+				PublicIPAddressVersion:   network.IPVersionIPv4,
+				PublicIPAllocationMethod: network.IPAllocationMethodStatic,
+			},
+			Location: &c.Region,
+			Sku: &network.PublicIPAddressSku{
+				Name: network.PublicIPAddressSkuNameStandard,
+			},
+		},
+	)
+	if err != nil {
+		return ip, errors.Wrapf(err, "cannot create public ip address: %q", ipName)
+	}
+
+	err = future.WaitForCompletionRef(ctx, ipClient.Client)
+	if err != nil {
+		return ip, errors.Wrapf(err, "cannot get public ip address create or update future response: %q", ipName)
+	}
+
+	ipAddress, err := future.Result(*ipClient)
+
+	return ipAddress, errors.Wrapf(err, "Error getting the public ip %q", ipName)
+}
+
+func (c *CloudInfo) DeletePublicIP(ctx context.Context, ipClient *network.PublicIPAddressesClient, ipName string,
+) (err error) {
+	future, err := ipClient.Delete(ctx, c.BaseGroupName, ipName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete public ip : %q", ipName)
+	}
+
+	err = future.WaitForCompletionRef(ctx, ipClient.Client)
+	if err != nil {
+		return errors.Wrapf(err, "failed to remove the public ip : %q", ipName)
+	}
+
+	return nil
 }


### PR DESCRIPTION
*  Add support to tag an existing node as g/w node
*  Open the required ports to enable g/w traffic
*  Removes the security groups and removes the tag in cleanup.

Fixes : submariner-io/cloud-prepare#289

Signed-off-by: Aswin Suryanarayanan <aswinsuryan@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
