### PR TITLE
Limit Azure machine name lengths to 40 characters

### DIFF
--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	submarinerGatewayGW      = "subgw"
+	submarinerGatewayGW      = "-subgw-"
 	azureVirtualMachines     = "virtualMachines"
 	topologyLabel            = "topology.kubernetes.io/zone"
 	submarinerGatewayNodeTag = "submariner-io-gateway-node"
@@ -267,14 +267,39 @@ func (d *ocpGatewayDeployer) initMachineSet(name, zone string) (*unstructured.Un
 }
 
 func (d *ocpGatewayDeployer) deployGateway(zone string) error {
-	name := d.azure.InfraID + submarinerGatewayGW + d.azure.Region + "-" + zone
-
-	machineSet, err := d.initMachineSet(name, zone)
+	machineSet, err := d.initMachineSet(MachineName(d.azure.InfraID, d.azure.Region, zone), zone)
 	if err != nil {
 		return err
 	}
 
 	return errors.Wrapf(d.msDeployer.Deploy(machineSet), "error deploying machine set %q", machineSet.GetName())
+}
+
+// MachineName generates a machine name for the gateway.
+// The name length is limited to 40 characters to ensure we don't hit the 63-character limit
+// when generating the "machine public IP name".
+// At most 6 characters for the zone (which is usually very short),
+// at most 12 for the region and zone combined,
+// at most 32 for the infra id, region and zone combined
+// (the infra id is the longest significant piece of information here).
+// We add "-subgw-", 7 characters, for a total of 40 with the hyphen between region and zone.
+func MachineName(infraID, region, zone string) string {
+	if len(infraID)+len(region)+len(zone) > 32 {
+		// Limit the name length to 40 characters
+		if len(zone) > 6 {
+			zone = zone[0:6]
+		}
+
+		if len(region) > 12-len(zone) {
+			region = region[0 : 12-len(zone)]
+		}
+
+		if len(infraID) > 32-len(zone)-len(region) {
+			infraID = infraID[0 : 32-len(zone)-len(region)]
+		}
+	}
+
+	return infraID + submarinerGatewayGW + region + "-" + zone
 }
 
 func (d *ocpGatewayDeployer) getAvailabilityZones(gwNodes []v1.Node) (stringset.Interface, error) {

--- a/pkg/azure/ocpgwdeployer_test.go
+++ b/pkg/azure/ocpgwdeployer_test.go
@@ -1,0 +1,43 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/cloud-prepare/pkg/azure"
+)
+
+func TestAzure(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Azure Suite")
+}
+
+var _ = Describe("OCP Gateway Deployer", func() {
+	Describe("MachineName", func() {
+		It("should be at most 40 characters in length", func() {
+			Expect(len(azure.MachineName("acmqe-clc-auto-azure6-fd55b", "centralus", "3"))).To(BeNumerically("<=", 40))
+			Expect(len(azure.MachineName("acmqe-clc-auto-azure6-fd55b", "centraleurope", "3"))).To(BeNumerically("<=", 40))
+			Expect(len(azure.MachineName("acmqe-clc-auto-azure6-fd55b", "centralus", "bigzone"))).To(BeNumerically("<=", 40))
+			Expect(azure.MachineName("acmqe-clc-auto-azure6-fd55b", "us", "1")).To(HavePrefix("acmqe-clc-auto-azure6-fd55b"))
+		})
+	})
+})


### PR DESCRIPTION
To avoid hitting the 63-character limit on "machine IP names", which
are generated using the provided machine names, limit the latter to 40
characters.

The MachineName function is exported for the unit test to limit the
changes required for this fix; a proper test would require a full
driver setup as in other packages.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
