### PR TITLE
Remove hardcoded workerNodeList while querying image

### DIFF
--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -256,8 +256,7 @@ func (d *ocpGatewayDeployer) deployGateway(zone string) error {
 	}
 
 	if d.image == "" {
-		// TODO: use machineSetClient.List() instead of hard coding.
-		workerNodeList := []string{d.InfraID + "-worker-b", d.InfraID + "-worker-c", d.InfraID + "-worker-d"}
+		workerNodeList := []string{}
 
 		d.image, err = d.msDeployer.GetWorkerNodeImage(workerNodeList, machineSet, d.InfraID)
 		if err != nil {

--- a/pkg/ocp/machinesets.go
+++ b/pkg/ocp/machinesets.go
@@ -21,6 +21,7 @@ package ocp
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/resource"
@@ -41,6 +42,7 @@ type MachineSetDeployer interface {
 	Deploy(machineSet *unstructured.Unstructured) error
 
 	// GetWorkerNodeImage returns the image used by OCP worker nodes.
+	// If an empty workerNodeList is passed, the API will internally query the worker nodes.
 	GetWorkerNodeImage(workerNodeList []string, machineSet *unstructured.Unstructured, infraID string) (string, error)
 
 	// Delete will remove the given machineset.
@@ -77,6 +79,17 @@ func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(workerNodeList []string, ma
 		return "", err
 	}
 
+	if len(workerNodeList) == 0 {
+		nodeList, err := machineSetClient.List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return "", errors.Wrapf(err, "error listing the machineSets")
+		}
+
+		for _, machineName := range nodeList.Items {
+			workerNodeList = append(workerNodeList, machineName.GetName())
+		}
+	}
+
 	for _, nodeName := range workerNodeList {
 		existing, err := machineSetClient.Get(context.TODO(), nodeName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
@@ -85,6 +98,14 @@ func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(workerNodeList []string, ma
 
 		if err != nil {
 			return "", errors.Wrapf(err, "error retrieving machine set %q", nodeName)
+		}
+
+		labels, found, _ := unstructured.NestedStringMap(existing.Object, "spec", "template", "metadata", "labels")
+		if found {
+			role := labels["machine.openshift.io/cluster-api-machine-role"]
+			if strings.Compare(strings.ToLower(role), "worker") != 0 {
+				continue
+			}
 		}
 
 		disks, _, _ := unstructured.NestedSlice(existing.Object, "spec", "template", "spec", "providerSpec", "value", "disks")

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -121,8 +121,7 @@ func (d *ocpGatewayDeployer) deployGateway(index string) error {
 	}
 
 	if d.image == "" {
-		// TODO: use machineSetClient.List() instead of hard coding.
-		workerNodeList := []string{d.InfraID + "-worker-0", d.InfraID + "-worker-1", d.InfraID + "-worker-2"}
+		workerNodeList := []string{}
 
 		d.image, err = d.msDeployer.GetWorkerNodeImage(workerNodeList, machineSet, d.InfraID)
 		if err != nil {


### PR DESCRIPTION
Currently, as part of gcp and rhos cloud preparation, the code requires the image to be used for the dedicated GW node. For this, we have a hard-coded list of machineSets which is error prone. This PR fixes the issue by internally querying the machineSets when an empty list is passed and also retains the existing API signature allowing the clients to explicitly specify the workerNodeList if required.

Fixes: https://github.com/submariner-io/cloud-prepare/issues/201
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
