### PR TITLE
Add broken MD links GHA

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -1,0 +1,32 @@
+---
+name: Periodic
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+
+permissions: {}
+
+jobs:
+  markdown-link-check-periodic:
+    name: Markdown Links (all files)
+    if: github.repository_owner == 'submariner-io'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+
+      - name: Run markdown-link-check
+        uses: gaurav-nelson/github-action-markdown-link-check@228fbf4ffb2a86a65314866e9b2322b519fd885f
+        with:
+          config-file: ".markdownlinkcheck.json"
+
+      - name: Raise an Issue to report broken links
+        if: ${{ failure() }}
+        uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f
+        with:
+          title: Broken link detected by periodic linting
+          content-filepath: .github/ISSUE_TEMPLATE/broken-link.md
+          labels: automated, broken link


### PR DESCRIPTION
Add periodic test that audits markdown for broken links and reports an issue if a broken link is found.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
