### PR TITLE
Remove space between // and nolint

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:wrapcheck // The functions are simple wrappers so let the caller wrap errors.
+//nolint:wrapcheck // The functions are simple wrappers so let the caller wrap errors.
 package client
 
 import (

--- a/pkg/aws/ocpgwdeployer_test.go
+++ b/pkg/aws/ocpgwdeployer_test.go
@@ -366,7 +366,7 @@ func (t *gatewayDeployerTestDriver) testDeploySuccess(msgPrefix, msgSuffix strin
 	})
 }
 
-// nolint:gocritic // Error: "consider `machineSets' to be of non-pointer type"
+//nolint:gocritic // Error: "consider `machineSets' to be of non-pointer type"
 func machineSetFn(machineSets *map[string]*unstructured.Unstructured) func(ms *unstructured.Unstructured) error {
 	*machineSets = map[string]*unstructured.Unstructured{}
 

--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -209,7 +209,7 @@ func (ac *awsCloud) deleteGatewaySG(vpcID string) error {
 			GroupId: gatewayGroupID,
 		})
 
-		return err // nolint:wrapcheck // Let the caller wrap it.
+		return err //nolint:wrapcheck // Let the caller wrap it.
 	})
 
 	if isAWSError(err, "InvalidPermission.NotFound") {

--- a/pkg/aws/subnets.go
+++ b/pkg/aws/subnets.go
@@ -79,7 +79,7 @@ func (ac *awsCloud) getSubnetsSupportingInstanceType(subnets []types.Subnet, ins
 			},
 		})
 		if err != nil {
-			return false, err // nolint:wrapcheck // Let the caller wrap it.
+			return false, err //nolint:wrapcheck // Let the caller wrap it.
 		}
 
 		return len(output.InstanceTypeOfferings) > 0, nil

--- a/pkg/azure/cloud_info.go
+++ b/pkg/azure/cloud_info.go
@@ -52,22 +52,22 @@ type CloudInfo struct {
 	K8sClient       k8s.Interface
 }
 
-// nolint:wrapcheck // Let the caller wrap it.
+//nolint:wrapcheck // Let the caller wrap it.
 func (c *CloudInfo) getNsgClient() (*armnetwork.SecurityGroupsClient, error) {
 	return armnetwork.NewSecurityGroupsClient(c.SubscriptionID, c.TokenCredential, nil)
 }
 
-// nolint:wrapcheck // Let the caller wrap it.
+//nolint:wrapcheck // Let the caller wrap it.
 func (c *CloudInfo) getInterfacesClient() (*armnetwork.InterfacesClient, error) {
 	return armnetwork.NewInterfacesClient(c.SubscriptionID, c.TokenCredential, nil)
 }
 
-// nolint:wrapcheck // Let the caller wrap it.
+//nolint:wrapcheck // Let the caller wrap it.
 func (c *CloudInfo) getPublicIPClient() (*armnetwork.PublicIPAddressesClient, error) {
 	return armnetwork.NewPublicIPAddressesClient(c.SubscriptionID, c.TokenCredential, nil)
 }
 
-// nolint:wrapcheck // Let the caller wrap it.
+//nolint:wrapcheck // Let the caller wrap it.
 func (c *CloudInfo) getResourceSKUClient() (*armcompute.ResourceSKUsClient, error) {
 	return armcompute.NewResourceSKUsClient(c.SubscriptionID, c.TokenCredential, nil)
 }

--- a/pkg/gcp/client/client.go
+++ b/pkg/gcp/client/client.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:wrapcheck // The functions are wrappers so let the caller wrap errors.
+//nolint:wrapcheck // The functions are wrappers so let the caller wrap errors.
 package client
 
 import (

--- a/pkg/gcp/ocpgwdeployer_test.go
+++ b/pkg/gcp/ocpgwdeployer_test.go
@@ -533,7 +533,7 @@ func labelNode(node *corev1.Node) *corev1.Node {
 	return node
 }
 
-// nolint:gocritic // Error: "consider `machineSets' to be of non-pointer type"
+//nolint:gocritic // Error: "consider `machineSets' to be of non-pointer type"
 func machineSetFn(machineSets *map[string]*unstructured.Unstructured) func(ms *unstructured.Unstructured) error {
 	*machineSets = map[string]*unstructured.Unstructured{}
 

--- a/pkg/k8s/k8siface.go
+++ b/pkg/k8s/k8siface.go
@@ -72,7 +72,7 @@ func (k *k8sIface) ListGatewayNodes() (*v1.NodeList, error) {
 }
 
 func (k *k8sIface) updateLabel(nodeName string, mutate func(existing *v1.Node)) error {
-	// nolint:wrapcheck // Let the caller wrap these errors.
+	//nolint:wrapcheck // Let the caller wrap these errors.
 	client := &resource.InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
 			return k.clientSet.CoreV1().Nodes().Get(ctx, name, options)


### PR DESCRIPTION
This is enforced by newer releases of golangci-lint.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
