### PR TITLE
Don't tag Submariner SG as cluster-owned

### DIFF
--- a/pkg/aws/aws_suite_test.go
+++ b/pkg/aws/aws_suite_test.go
@@ -180,10 +180,6 @@ func (f *fakeAWSClientBase) expectCreateSecurityGroup(name, retGroupID string) {
 						Key:   awssdk.String("Name"),
 						Value: awssdk.String(name),
 					},
-					{
-						Key:   awssdk.String("kubernetes.io/cluster/" + infraID),
-						Value: awssdk.String("owned"),
-					},
 				},
 			},
 		},

--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -157,7 +157,6 @@ func (ac *awsCloud) createGatewaySG(vpcID string, ports []api.PortSpec) (string,
 					ResourceType: types.ResourceTypeSecurityGroup,
 					Tags: []types.Tag{
 						ec2Tag("Name", groupName),
-						ec2Tag(ac.withAWSInfo("kubernetes.io/cluster/{infraID}"), "owned"),
 					},
 				},
 			},


### PR DESCRIPTION
Setting the Submariner SG as cluster-owned results in multiple SGs being found for load-balancer services, which isn't supported. This was previously fixed in commit 54e25267a87e ("Remove the cluster owned tag from submariner sg") in the Submariner project.

See https://github.com/kubernetes/kubernetes/issues/73906 and https://bugzilla.redhat.com/show_bug.cgi?id=2139477

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
