### PR TITLE
Automated backport of #446: Don't tag Submariner SG as cluster-owned

### DIFF
--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -157,7 +157,6 @@ func (ac *awsCloud) createGatewaySG(vpcID string, ports []api.PortSpec) (string,
 					ResourceType: types.ResourceTypeSecurityGroup,
 					Tags: []types.Tag{
 						ec2Tag("Name", groupName),
-						ec2Tag(ac.withAWSInfo("kubernetes.io/cluster/{infraID}"), "owned"),
 					},
 				},
 			},


### PR DESCRIPTION
Backport of #446 on release-0.12.

#446: Don't tag Submariner SG as cluster-owned

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.