### PR TITLE
[Backport 0.12] Stop using cluster-owned tag for ASW SG lookup

### DIFF
--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -48,7 +48,6 @@ func (ac *awsCloud) getSecurityGroup(vpcID, name string) (types.SecurityGroup, e
 	filters := []types.Filter{
 		ec2Filter("vpc-id", vpcID),
 		ac.filterByName(name),
-		ac.filterByCurrentCluster(),
 	}
 
 	result, err := ac.client.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{


### PR DESCRIPTION
Since we're not tagging the gateway security group as "cluster owned" anymore, the deletion fails silently since it can't find it.

As we're querying for security groups based on infra ID encoded in the group name, and the VPC ID, we should be fine dropping this tag from the lookup filters.

Conflicts:
  pkg/aws/aws_suite_test.go

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit 7c77b6b76db092d8cba7880edaad8e2b84530693)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
