### PR TITLE
Fix issues in cloud prepare for Azure and RHOS

### DIFF
--- a/pkg/azure/ocpgwdeployer_test.go
+++ b/pkg/azure/ocpgwdeployer_test.go
@@ -34,10 +34,10 @@ func TestAzure(t *testing.T) {
 var _ = Describe("OCP Gateway Deployer", func() {
 	Describe("MachineName", func() {
 		It("should be at most 40 characters in length", func() {
-			Expect(len(azure.MachineName("acmqe-clc-auto-azure6-fd55b", "centralus", "3"))).To(BeNumerically("<=", 40))
-			Expect(len(azure.MachineName("acmqe-clc-auto-azure6-fd55b", "centraleurope", "3"))).To(BeNumerically("<=", 40))
-			Expect(len(azure.MachineName("acmqe-clc-auto-azure6-fd55b", "centralus", "bigzone"))).To(BeNumerically("<=", 40))
-			Expect(azure.MachineName("acmqe-clc-auto-azure6-fd55b", "us", "1")).To(HavePrefix("acmqe-clc-auto-azure6-fd55b"))
+			Expect(len(azure.MachineName("centralus"))).To(BeNumerically("<=", 20))
+			Expect(len(azure.MachineName("centraleurope"))).To(BeNumerically("<=", 20))
+			Expect(len(azure.MachineName("centralus"))).To(BeNumerically("<=", 20))
+			Expect(azure.MachineName("us")).To(HavePrefix("subgw-us-"))
 		})
 	})
 })

--- a/pkg/gcp/ocpgwdeployer_test.go
+++ b/pkg/gcp/ocpgwdeployer_test.go
@@ -193,7 +193,7 @@ func testDeploy() {
 		var machineSets map[string]*unstructured.Unstructured
 
 		BeforeEach(func() {
-			t.msDeployer.EXPECT().GetWorkerNodeImage(gomock.Any(), infraID).Return("test-image", nil).AnyTimes()
+			t.msDeployer.EXPECT().GetWorkerNodeImage(gomock.Any(), gomock.Any(), infraID).Return("test-image", nil).AnyTimes()
 			t.msDeployer.EXPECT().Deploy(gomock.Any()).DoAndReturn(machineSetFn(&machineSets)).Times(2)
 
 			t.dedicatedGWNode = true

--- a/pkg/ocp/fake/machineset.go
+++ b/pkg/ocp/fake/machineset.go
@@ -1,14 +1,10 @@
 /*
 SPDX-License-Identifier: Apache-2.0
-
 Copyright Contributors to the Submariner project.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
 http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -65,6 +61,20 @@ func (mr *MockMachineSetDeployerMockRecorder) Delete(machineSet interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockMachineSetDeployer)(nil).Delete), machineSet)
 }
 
+// DeleteByName mocks base method.
+func (m *MockMachineSetDeployer) DeleteByName(name, namespace string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByName", name, namespace)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByName indicates an expected call of DeleteByName.
+func (mr *MockMachineSetDeployerMockRecorder) DeleteByName(name, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByName", reflect.TypeOf((*MockMachineSetDeployer)(nil).DeleteByName), name, namespace)
+}
+
 // Deploy mocks base method.
 func (m *MockMachineSetDeployer) Deploy(machineSet *unstructured.Unstructured) error {
 	m.ctrl.T.Helper()
@@ -82,29 +92,29 @@ func (mr *MockMachineSetDeployerMockRecorder) Deploy(machineSet interface{}) *go
 // GetWorkerNodeImage mocks base method.
 func (m *MockMachineSetDeployer) GetWorkerNodeImage(workerNodeList []string, machineSet *unstructured.Unstructured, infraID string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkerNodeImage", machineSet, infraID)
+	ret := m.ctrl.Call(m, "GetWorkerNodeImage", workerNodeList, machineSet, infraID)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkerNodeImage indicates an expected call of GetWorkerNodeImage.
-func (mr *MockMachineSetDeployerMockRecorder) GetWorkerNodeImage(machineSet, infraID interface{}) *gomock.Call {
+func (mr *MockMachineSetDeployerMockRecorder) GetWorkerNodeImage(workerNodeList, machineSet, infraID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerNodeImage", reflect.TypeOf((*MockMachineSetDeployer)(nil).GetWorkerNodeImage), machineSet, infraID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerNodeImage", reflect.TypeOf((*MockMachineSetDeployer)(nil).GetWorkerNodeImage), workerNodeList, machineSet, infraID)
 }
 
-// List mocks base method
-func (m *MockMachineSetDeployer) List(machineSet *unstructured.Unstructured, name string) ([]unstructured.Unstructured, error) {
+// List mocks base method.
+func (m *MockMachineSetDeployer) List() ([]unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", machineSet, name)
+	ret := m.ctrl.Call(m, "List")
 	ret0, _ := ret[0].([]unstructured.Unstructured)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// List indicates an expected call of List
-func (mr *MockMachineSetDeployerMockRecorder) List(machineSet, name interface{}) *gomock.Call {
+// List indicates an expected call of List.
+func (mr *MockMachineSetDeployerMockRecorder) List() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockMachineSetDeployer)(nil).List), machineSet, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockMachineSetDeployer)(nil).List))
 }


### PR DESCRIPTION
Fix issues in the cloud prepare for Azure and RHOS

1) Fix Azure machine set name now changed to region + uuid
and limited to 20 characters to prevent issues long cluster
name

2) Machine set creation and deletion logic updated. Now it lists
machines set to check for existing dedicated nodes and clean up
gateway nodes along with tagged g/w nodes. Earlier it listed
only tagged nodes. This resulted in the creation of multiple g/w nodes
cases when cloud prepare is run multiple times due to a delay in the creation
g/w nodes from the machine set.

Fixes: https://github.com/stolostron/backlog/issues/25111

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
