### PR TITLE
Change frequency of dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,25 +4,39 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: github-actions
     directory: '/'
     target-branch: "release-0.12"
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: github-actions
     directory: '/'
     target-branch: "release-0.13"
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: github-actions
     directory: '/'
     target-branch: "release-0.14"
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: weekly
     ignore:
+      # Our own dependencies are handled during releases
       - dependency-name: github.com/submariner-io/*
+      # These are checked monthly below
+      - dependency-name: github.com/aws/aws-sdk-go-v2/*
+      - dependency-name: github.com/Azure/azure-sdk-for-go/*
+      # These are included by k8s.io/client-go
+      - dependency-name: k8s.io/api
+      - dependency-name: k8s.io/apimachinery
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: monthly
+    allow:
+      - dependency-name: github.com/aws/aws-sdk-go-v2/*
+      - dependency-name: github.com/Azure/azure-sdk-for-go/*


### PR DESCRIPTION
- Monthly for gh-actions
- Monthly for AWS and Azure dependencies whose normal version cadence is 1-3 weeks
- Ignore k8s dependencies included with client-go
