### PR TITLE
Warn and return when no ports given to `OpenPorts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,33 +18,24 @@ These capabilities aim to be idempotent, so in case of failure or other necessit
 
 The API defines a `Reporter` type which has the capability to report on the latest operation performed in the cloud.
 
-### Prepare a cloud for Submariner
+### Open internal ports for Submariner
 
-The `PrepareForSubmarinerInput` function takes the number of gateways, the internal ports used for intra-cluster communication between
-Submariner components, and the public ports used for inter-cluster communication between Submariner gateways.
+The `OpenPorts` function opens the internal ports used for intra-cluster communication between Submariner components.
 
 ```go
-	input := api.PrepareForSubmarinerInput{
-		InternalPorts: []api.PortSpec{
-			{Port: vxlanPort, Protocol: "udp"},
-			{Port: metricsPort, Protocol: "tcp"},
-		},
-		PublicPorts: []api.PortSpec{
-			{Port: nattPort, Protocol: "udp"},
-			{Port: natDiscoveryPort, Protocol: "udp"},
-		},
-		Gateways: gateways,
-	}
-	err := cloud.PrepareForSubmariner(input, reporter)
+	err := cloud.OpenPorts([]api.PortSpec{
+            {Port: vxlanPort, Protocol: "udp"},
+            {Port: metricsPort, Protocol: "tcp"},
+        }, reporter)
 
 ```
 
-### Clean up a cloud after Submariner has been uninstalled
+### Close internal ports after Submariner has been uninstalled
 
-The `CleanupAfterSubmariner` function reverses all the preparation work previously done by the library.
+The `ClosePorts` function closes all internal ports previously opened by the library.
 
 ```go
-	err := cloud.CleanupAfterSubmariner(reporter)
+	err := cloud.ClosePorts(reporter)
 ```
 
 ## Supported Cloud Providers

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -26,18 +26,13 @@ type PortSpec struct {
 	Protocol string
 }
 
-type PrepareForSubmarinerInput struct {
-	// List of ports to open inside the cluster for proper communication between Submariner services.
-	InternalPorts []PortSpec
-}
-
 // Cloud is a potential cloud for installing Submariner on.
 type Cloud interface {
-	// PrepareForSubmariner will prepare the cloud for Submariner to operate on.
-	PrepareForSubmariner(input PrepareForSubmarinerInput, status reporter.Interface) error
+	// OpenPorts inside the cloud for submariner to communicate through.
+	OpenPorts(ports []PortSpec, status reporter.Interface) error
 
-	// CleanupAfterSubmariner will clean up the cloud after Submariner is removed.
-	CleanupAfterSubmariner(status reporter.Interface) error
+	// ClosePorts will close any internal ports that were opened, after Submariner is removed.
+	ClosePorts(status reporter.Interface) error
 }
 
 type GatewayDeployInput struct {

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -88,7 +88,7 @@ func DefaultProfile() string {
 	return "default"
 }
 
-func (ac *awsCloud) PrepareForSubmariner(input api.PrepareForSubmarinerInput, status reporter.Interface) error {
+func (ac *awsCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {
 	status.Start(messageRetrieveVPCID)
 	defer status.End()
 
@@ -108,7 +108,7 @@ func (ac *awsCloud) PrepareForSubmariner(input api.PrepareForSubmarinerInput, st
 
 	status.Success(messageValidatedPrerequisites)
 
-	for _, port := range input.InternalPorts {
+	for _, port := range ports {
 		status.Start("Opening port %v protocol %s for intra-cluster communications", port.Port, port.Protocol)
 
 		err = ac.allowPortInCluster(vpcID, port.Port, port.Protocol)
@@ -126,7 +126,7 @@ func (ac *awsCloud) validatePreparePrerequisites(vpcID string) error {
 	return ac.validateCreateSecGroupRule(vpcID)
 }
 
-func (ac *awsCloud) CleanupAfterSubmariner(status reporter.Interface) error {
+func (ac *awsCloud) ClosePorts(status reporter.Interface) error {
 	status.Start(messageRetrieveVPCID)
 	defer status.End()
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -89,8 +89,14 @@ func DefaultProfile() string {
 }
 
 func (ac *awsCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {
-	status.Start(messageRetrieveVPCID)
 	defer status.End()
+
+	if len(ports) == 0 {
+		status.Warning("Ignoring attempt to open ports with no ports given")
+		return nil
+	}
+
+	status.Start(messageRetrieveVPCID)
 
 	vpcID, err := ac.getVpcID()
 	if err != nil {

--- a/pkg/aws/aws_cloud_test.go
+++ b/pkg/aws/aws_cloud_test.go
@@ -29,11 +29,11 @@ import (
 )
 
 var _ = Describe("Cloud", func() {
-	Describe("PrepareForSubmariner", testPrepareForSubmariner)
-	Describe("CleanupAfterSubmariner", testCleanupAfterSubmariner)
+	Describe("OpenPorts", testOpenPorts)
+	Describe("ClosePorts", testClosePorts)
 })
 
-func testPrepareForSubmariner() {
+func testOpenPorts() {
 	t := newCloudTestDriver()
 
 	var retError error
@@ -41,16 +41,14 @@ func testPrepareForSubmariner() {
 	JustBeforeEach(func() {
 		t.expectDescribeVpcs(t.vpcID)
 
-		retError = t.cloud.PrepareForSubmariner(api.PrepareForSubmarinerInput{
-			InternalPorts: []api.PortSpec{
-				{
-					Port:     100,
-					Protocol: "TCP",
-				},
-				{
-					Port:     200,
-					Protocol: "UDP",
-				},
+		retError = t.cloud.OpenPorts([]api.PortSpec{
+			{
+				Port:     100,
+				Protocol: "TCP",
+			},
+			{
+				Port:     200,
+				Protocol: "UDP",
 			},
 		}, reporter.Stdout())
 	})
@@ -109,7 +107,7 @@ func testPrepareForSubmariner() {
 	})
 }
 
-func testCleanupAfterSubmariner() {
+func testClosePorts() {
 	t := newCloudTestDriver()
 
 	var retError error
@@ -117,7 +115,7 @@ func testCleanupAfterSubmariner() {
 	JustBeforeEach(func() {
 		t.expectDescribeVpcs(t.vpcID)
 
-		retError = t.cloud.CleanupAfterSubmariner(reporter.Stdout())
+		retError = t.cloud.ClosePorts(reporter.Stdout())
 	})
 
 	Context("on success", func() {

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -37,7 +37,7 @@ func NewCloud(info *CloudInfo) api.Cloud {
 	}
 }
 
-func (az *azureCloud) PrepareForSubmariner(input api.PrepareForSubmarinerInput, reporter reporterInterface.Interface) error {
+func (az *azureCloud) OpenPorts(ports []api.PortSpec, reporter reporterInterface.Interface) error {
 	reporter.Start("Opening internal ports for intra-cluster communications on Azure")
 
 	nsgClient, err := az.getNsgClient()
@@ -45,17 +45,16 @@ func (az *azureCloud) PrepareForSubmariner(input api.PrepareForSubmarinerInput, 
 		return reporter.Error(err, "Failed to get network security groups client")
 	}
 
-	if err := az.openInternalPorts(az.InfraID, input.InternalPorts, nsgClient); err != nil {
+	if err := az.openInternalPorts(az.InfraID, ports, nsgClient); err != nil {
 		return reporter.Error(err, "Failed to open internal ports")
 	}
 
-	reporter.Success("Opened internal ports %q for intra-cluster communications on Azure",
-		formatPorts(input.InternalPorts))
+	reporter.Success("Opened internal ports %q for intra-cluster communications on Azure", formatPorts(ports))
 
 	return nil
 }
 
-func (az *azureCloud) CleanupAfterSubmariner(reporter reporterInterface.Interface) error {
+func (az *azureCloud) ClosePorts(reporter reporterInterface.Interface) error {
 	reporter.Start("Revoking intra-cluster communication permissions")
 
 	nsgClient, err := az.getNsgClient()

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -38,6 +38,13 @@ func NewCloud(info *CloudInfo) api.Cloud {
 }
 
 func (az *azureCloud) OpenPorts(ports []api.PortSpec, reporter reporterInterface.Interface) error {
+	defer reporter.End()
+
+	if len(ports) == 0 {
+		reporter.Warning("Ignoring attempt to open ports with no ports given")
+		return nil
+	}
+
 	reporter.Start("Opening internal ports for intra-cluster communications on Azure")
 
 	nsgClient, err := az.getNsgClient()

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -35,25 +35,23 @@ func NewCloud(info CloudInfo) api.Cloud {
 	return &gcpCloud{CloudInfo: info}
 }
 
-// PrepareForSubmariner prepares submariner cluster environment on GCP.
-func (gc *gcpCloud) PrepareForSubmariner(input api.PrepareForSubmarinerInput, status reporter.Interface) error {
+func (gc *gcpCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {
 	// Create the inbound firewall rule for submariner internal ports.
-	status.Start("Opening internal ports %q for intra-cluster communications on GCP", formatPorts(input.InternalPorts))
+	status.Start("Opening internal ports %q for intra-cluster communications on GCP", formatPorts(ports))
 	defer status.End()
 
-	internalIngress := newInternalFirewallRule(gc.ProjectID, gc.InfraID, input.InternalPorts)
+	internalIngress := newInternalFirewallRule(gc.ProjectID, gc.InfraID, ports)
 	if err := gc.openPorts(internalIngress); err != nil {
 		return status.Error(err, "unable to open ports")
 	}
 
 	status.Success("Opened internal ports %q with firewall rule %q on GCP",
-		formatPorts(input.InternalPorts), internalIngress.Name)
+		formatPorts(ports), internalIngress.Name)
 
 	return nil
 }
 
-// CleanupAfterSubmariner clean up submariner cluster environment on GCP.
-func (gc *gcpCloud) CleanupAfterSubmariner(status reporter.Interface) error {
+func (gc *gcpCloud) ClosePorts(status reporter.Interface) error {
 	// Delete the inbound and outbound firewall rules to close submariner internal ports.
 	internalIngressName := generateRuleName(gc.InfraID, internalPortsRuleName)
 

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -36,9 +36,15 @@ func NewCloud(info CloudInfo) api.Cloud {
 }
 
 func (gc *gcpCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {
+	defer status.End()
+
+	if len(ports) == 0 {
+		status.Warning("Ignoring attempt to open ports with no ports given")
+		return nil
+	}
+
 	// Create the inbound firewall rule for submariner internal ports.
 	status.Start("Opening internal ports %q for intra-cluster communications on GCP", formatPorts(ports))
-	defer status.End()
 
 	internalIngress := newInternalFirewallRule(gc.ProjectID, gc.InfraID, ports)
 	if err := gc.openPorts(internalIngress); err != nil {

--- a/pkg/gcp/gcp_cloud_test.go
+++ b/pkg/gcp/gcp_cloud_test.go
@@ -35,26 +35,24 @@ import (
 const ingressRuleName = "test-infraID-submariner-internal-ports-ingress"
 
 var _ = Describe("Cloud", func() {
-	Describe("PrepareForSubmariner", testPrepareForSubmariner)
-	Describe("CleanupAfterSubmariner", testCleanupAfterSubmariner)
+	Describe("OpenPorts", testOpenPorts)
+	Describe("ClosePorts", testClosePorts)
 })
 
-func testPrepareForSubmariner() {
+func testOpenPorts() {
 	t := newCloudTestDriver()
 
 	var retError error
 
 	JustBeforeEach(func() {
-		retError = t.cloud.PrepareForSubmariner(api.PrepareForSubmarinerInput{
-			InternalPorts: []api.PortSpec{
-				{
-					Port:     100,
-					Protocol: "TCP",
-				},
-				{
-					Port:     200,
-					Protocol: "UDP",
-				},
+		retError = t.cloud.OpenPorts([]api.PortSpec{
+			{
+				Port:     100,
+				Protocol: "TCP",
+			},
+			{
+				Port:     200,
+				Protocol: "UDP",
 			},
 		}, reporter.Stdout())
 	})
@@ -141,13 +139,13 @@ func testPrepareForSubmariner() {
 	})
 }
 
-func testCleanupAfterSubmariner() {
+func testClosePorts() {
 	t := newCloudTestDriver()
 
 	var retError error
 
 	JustBeforeEach(func() {
-		retError = t.cloud.CleanupAfterSubmariner(reporter.Stdout())
+		retError = t.cloud.ClosePorts(reporter.Stdout())
 	})
 
 	Context("on success", func() {

--- a/pkg/rhos/rhos.go
+++ b/pkg/rhos/rhos.go
@@ -44,8 +44,14 @@ func NewCloud(info CloudInfo) api.Cloud {
 }
 
 func (rc *rhosCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {
-	status.Start("Opening internal ports for intra-cluster communications on RHOS")
 	defer status.End()
+
+	if len(ports) == 0 {
+		status.Warning("Ignoring attempt to open ports with no ports given")
+		return nil
+	}
+
+	status.Start("Opening internal ports for intra-cluster communications on RHOS")
 
 	computeClient, err := openstack.NewComputeV2(rc.Client, gophercloud.EndpointOpts{Region: rc.Region})
 	if err != nil {

--- a/pkg/rhos/rhos.go
+++ b/pkg/rhos/rhos.go
@@ -43,7 +43,7 @@ func NewCloud(info CloudInfo) api.Cloud {
 	}
 }
 
-func (rc *rhosCloud) PrepareForSubmariner(input api.PrepareForSubmarinerInput, status reporter.Interface) error {
+func (rc *rhosCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {
 	status.Start("Opening internal ports for intra-cluster communications on RHOS")
 	defer status.End()
 
@@ -57,16 +57,16 @@ func (rc *rhosCloud) PrepareForSubmariner(input api.PrepareForSubmarinerInput, s
 		return status.Error(err, "error creating the network client")
 	}
 
-	if err := rc.openInternalPorts(rc.InfraID, input.InternalPorts, computeClient, networkClient); err != nil {
+	if err := rc.openInternalPorts(rc.InfraID, ports, computeClient, networkClient); err != nil {
 		return status.Error(err, "unable to open ports")
 	}
 
-	status.Success("Opened internal ports %q for intra-cluster communications on RHOS", formatPorts(input.InternalPorts))
+	status.Success("Opened internal ports %q for intra-cluster communications on RHOS", formatPorts(ports))
 
 	return nil
 }
 
-func (rc *rhosCloud) CleanupAfterSubmariner(status reporter.Interface) error {
+func (rc *rhosCloud) ClosePorts(status reporter.Interface) error {
 	status.Start("Revoking intra-cluster communication permissions")
 
 	computeClient, err := openstack.NewComputeV2(rc.Client, gophercloud.EndpointOpts{Region: rc.Region})


### PR DESCRIPTION
As the operation for opening ports involves multiple communications with the cloud, and various necessary permissions, make sure that when no ports are given we don't try to do it but instead warn the user about it (as generally, callers should be wary of calling the API with no ports).

Depends on #571 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
