### PR TITLE
Use a single gomod / dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,20 +23,10 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     ignore:
       # Our own dependencies are handled during releases
       - dependency-name: github.com/submariner-io/*
-      # These are checked monthly below
-      - dependency-name: github.com/aws/aws-sdk-go-v2/*
-      - dependency-name: github.com/Azure/azure-sdk-for-go/*
       # These are included by k8s.io/client-go
       - dependency-name: k8s.io/api
       - dependency-name: k8s.io/apimachinery
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: monthly
-    allow:
-      - dependency-name: github.com/aws/aws-sdk-go-v2/*
-      - dependency-name: github.com/Azure/azure-sdk-for-go/*


### PR DESCRIPTION
dependabot doesn't support multiple configuration stanzas for a given ecosystem on a given branch, so we can't have a weekly configuration and a monthly configuration. This moves everything to monthly.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
