### PR TITLE
Avoid double MachineSet retrieval

### DIFF
--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -125,7 +125,7 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 	}
 
 	if d.dedicatedGWNode {
-		image, imageErr := d.msDeployer.GetWorkerNodeImage(nil, nil, d.InfraID)
+		image, imageErr := d.msDeployer.GetWorkerNodeImage(nil, d.InfraID)
 		if imageErr != nil {
 			return errors.Wrap(imageErr, "error retrieving worker node image")
 		}

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -256,9 +256,7 @@ func (d *ocpGatewayDeployer) deployGateway(zone string) error {
 	}
 
 	if d.image == "" {
-		workerNodeList := []string{}
-
-		d.image, err = d.msDeployer.GetWorkerNodeImage(workerNodeList, machineSet, d.InfraID)
+		d.image, err = d.msDeployer.GetWorkerNodeImage(machineSet, d.InfraID)
 		if err != nil {
 			return errors.Wrap(err, "error retrieving worker node image")
 		}

--- a/pkg/gcp/ocpgwdeployer_test.go
+++ b/pkg/gcp/ocpgwdeployer_test.go
@@ -193,7 +193,7 @@ func testDeploy() {
 		var machineSets map[string]*unstructured.Unstructured
 
 		BeforeEach(func() {
-			t.msDeployer.EXPECT().GetWorkerNodeImage(gomock.Any(), gomock.Any(), infraID).Return("test-image", nil).AnyTimes()
+			t.msDeployer.EXPECT().GetWorkerNodeImage(gomock.Any(), infraID).Return("test-image", nil).AnyTimes()
 			t.msDeployer.EXPECT().Deploy(gomock.Any()).DoAndReturn(machineSetFn(&machineSets)).Times(2)
 
 			t.dedicatedGWNode = true

--- a/pkg/ocp/fake/machineset.go
+++ b/pkg/ocp/fake/machineset.go
@@ -90,18 +90,18 @@ func (mr *MockMachineSetDeployerMockRecorder) Deploy(machineSet interface{}) *go
 }
 
 // GetWorkerNodeImage mocks base method.
-func (m *MockMachineSetDeployer) GetWorkerNodeImage(workerNodeList []string, machineSet *unstructured.Unstructured, infraID string) (string, error) {
+func (m *MockMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured.Unstructured, infraID string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkerNodeImage", workerNodeList, machineSet, infraID)
+	ret := m.ctrl.Call(m, "GetWorkerNodeImage", machineSet, infraID)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkerNodeImage indicates an expected call of GetWorkerNodeImage.
-func (mr *MockMachineSetDeployerMockRecorder) GetWorkerNodeImage(workerNodeList, machineSet, infraID interface{}) *gomock.Call {
+func (mr *MockMachineSetDeployerMockRecorder) GetWorkerNodeImage(machineSet, infraID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerNodeImage", reflect.TypeOf((*MockMachineSetDeployer)(nil).GetWorkerNodeImage), workerNodeList, machineSet, infraID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerNodeImage", reflect.TypeOf((*MockMachineSetDeployer)(nil).GetWorkerNodeImage), machineSet, infraID)
 }
 
 // List mocks base method.

--- a/pkg/ocp/machinesets_test.go
+++ b/pkg/ocp/machinesets_test.go
@@ -44,11 +44,10 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 	)
 
 	var (
-		msClient       dynamic.ResourceInterface
-		dynClient      *fakeClient.FakeDynamicClient
-		deployer       ocp.MachineSetDeployer
-		machineSet     *unstructured.Unstructured
-		workerNodeList = []string{infraID + "-worker-b", infraID + "-worker-c", infraID + "-worker-d"}
+		msClient   dynamic.ResourceInterface
+		dynClient  *fakeClient.FakeDynamicClient
+		deployer   ocp.MachineSetDeployer
+		machineSet *unstructured.Unstructured
 	)
 
 	BeforeEach(func() {
@@ -65,7 +64,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 	Context("on GetWorkerNodeImage", func() {
 		When("no worker node exists", func() {
 			It("should return an error", func() {
-				_, err := deployer.GetWorkerNodeImage(workerNodeList, machineSet, infraID)
+				_, err := deployer.GetWorkerNodeImage(machineSet, infraID)
 				Expect(err).ToNot(Succeed())
 			})
 		})
@@ -92,7 +91,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				})
 
 				It("should return its disk image", func() {
-					image, err := deployer.GetWorkerNodeImage(workerNodeList, machineSet, infraID)
+					image, err := deployer.GetWorkerNodeImage(machineSet, infraID)
 					Expect(err).To(Succeed())
 					Expect(image).To(Equal("some-image"))
 				})
@@ -100,7 +99,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 
 			Context("and has no disks", func() {
 				It("should return an error", func() {
-					_, err := deployer.GetWorkerNodeImage(workerNodeList, machineSet, infraID)
+					_, err := deployer.GetWorkerNodeImage(machineSet, infraID)
 					Expect(err).ToNot(Succeed())
 				})
 			})
@@ -109,12 +108,12 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				var expectedErr error
 
 				BeforeEach(func() {
-					expectedErr = errors.New("fake Get error")
-					fake.NewFailingReactor(&dynClient.Fake).SetFailOnGet(expectedErr)
+					expectedErr = errors.New("fake List error")
+					fake.NewFailingReactor(&dynClient.Fake).SetFailOnList(expectedErr)
 				})
 
 				It("should return an error", func() {
-					_, err := deployer.GetWorkerNodeImage(workerNodeList, machineSet, infraID)
+					_, err := deployer.GetWorkerNodeImage(machineSet, infraID)
 					Expect(err).To(ContainErrorSubstring(expectedErr))
 				})
 			})

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -120,9 +120,7 @@ func (d *ocpGatewayDeployer) deployGateway(index string) error {
 	}
 
 	if d.image == "" {
-		workerNodeList := []string{}
-
-		d.image, err = d.msDeployer.GetWorkerNodeImage(workerNodeList, machineSet, d.InfraID)
+		d.image, err = d.msDeployer.GetWorkerNodeImage(machineSet, d.InfraID)
 		if err != nil {
 			return errors.Wrap(err, "error getting the worker image")
 		}


### PR DESCRIPTION
GetWorkerNodeImage, if given an empty list of worker nodes, retrieves them all to extract their names, then retrieves them all *again* to process them. Avoid this by listing the nodes once, and processing that list.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
