### PR TITLE
Automated backport of #594: For Azure cloud prepare get the image from existing

### DIFF
--- a/pkg/azure/gw-machineset.go
+++ b/pkg/azure/gw-machineset.go
@@ -56,8 +56,7 @@ spec:
           image:
             offer: ""
             publisher: ""
-            resourceID: >-
-              /resourceGroups/{{.InfraID}}-rg/providers/Microsoft.Compute/images/{{.InfraID}}
+            resourceID: {{.Image}} 
             sku: ""
             version: ""
           internalLoadBalancer: ""

--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -126,7 +126,7 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 	if d.dedicatedGWNode {
 		image, imageErr := d.msDeployer.GetWorkerNodeImage(nil, nil, d.InfraID)
 		if imageErr != nil {
-			return errors.Wrap(err, "error retrieving worker node image")
+			return errors.Wrap(imageErr, "error retrieving worker node image")
 		}
 
 		err = d.deployDedicatedGWNode(machineSets, gatewayNodesToDeploy, image, status)


### PR DESCRIPTION
Backport of #594 on release-0.13.

#594: For Azure cloud prepare get the image from existing

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.