### PR TITLE
Label gw nodes as infra

### DIFF
--- a/pkg/aws/gw-machineset.go
+++ b/pkg/aws/gw-machineset.go
@@ -42,6 +42,7 @@ spec:
       metadata:
         labels:
           submariner.io/gateway: "true"
+          node-role.kubernetes.io/infra: ""
       taints:
         - effect: NoSchedule
           key: node-role.submariner.io/gateway

--- a/pkg/aws/gw-machineset.yaml.template
+++ b/pkg/aws/gw-machineset.yaml.template
@@ -23,6 +23,7 @@ spec:
       metadata:
         labels:
           submariner.io/gateway: "true"
+          node-role.kubernetes.io/infra: ""
       taints:
         - effect: NoSchedule
           key: node-role.submariner.io/gateway

--- a/pkg/azure/gw-machineset.go
+++ b/pkg/azure/gw-machineset.go
@@ -44,6 +44,7 @@ spec:
       metadata:
         labels:
           submariner.io/gateway: "true"
+          node-role.kubernetes.io/infra: ""
       taints:
         - effect: NoSchedule
           key: node-role.submariner.io/gateway

--- a/pkg/gcp/gw-machineset.go
+++ b/pkg/gcp/gw-machineset.go
@@ -42,6 +42,7 @@ spec:
       metadata:
         labels:
           submariner.io/gateway: "true"
+          node-role.kubernetes.io/infra: ""
       taints:
         - effect: NoSchedule
           key: node-role.submariner.io/gateway

--- a/pkg/rhos/gw-machineset.go
+++ b/pkg/rhos/gw-machineset.go
@@ -44,6 +44,7 @@ spec:
       metadata:
         labels:
           submariner.io/gateway: "true"
+          node-role.kubernetes.io/infra: ""
       taints:
         - effect: NoSchedule
           key: node-role.submariner.io/gateway


### PR DESCRIPTION
Add `node-role.kubernetes.io/infra=""` label to
gateway nodes.

Fixes #607

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
