### PR TITLE
Automated backport of #672: Ignore "InvalidGroup.Duplicate" AWS error

### DIFF
--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -162,7 +162,8 @@ func (ac *awsCloud) createGatewaySG(vpcID string, ports []api.PortSpec) (string,
 		}
 
 		result, err := ac.client.CreateSecurityGroup(context.TODO(), input)
-		if err != nil {
+
+		if err != nil && !isAWSError(err, "InvalidGroup.Duplicate") {
 			return "", errors.Wrap(err, "error creating AWS security group")
 		}
 


### PR DESCRIPTION
Backport of #672 on release-0.15.

#672: Ignore "InvalidGroup.Duplicate" AWS error

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.