### PR TITLE
Automated backport of #671: Skip adding internal Security group in machineset

### DIFF
--- a/pkg/rhos/gw-machineset.go
+++ b/pkg/rhos/gw-machineset.go
@@ -25,21 +25,21 @@ metadata:
     machine.openshift.io/cluster-api-cluster: {{.InfraID}}
     machine.openshift.io/cluster-api-machine-role: worker
     machine.openshift.io/cluster-api-machine-type: worker
-  name: {{.InfraID}}-submariner-gw-{{.Index}}
+  name: {{.InfraID}}-submariner-gw-{{.UUID}}
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: {{.InfraID}}
-      machine.openshift.io/cluster-api-machineset: {{.InfraID}}-submariner-gw-{{.Index}}
+      machine.openshift.io/cluster-api-machineset: {{.InfraID}}-submariner-gw-{{.UUID}}
   template:
     metadata:
       labels:
         machine.openshift.io/cluster-api-cluster: {{.InfraID}}
         machine.openshift.io/cluster-api-machine-role: worker
         machine.openshift.io/cluster-api-machine-type: worker
-        machine.openshift.io/cluster-api-machineset: {{.InfraID}}-submariner-gw-{{.Index}}
+        machine.openshift.io/cluster-api-machineset: {{.InfraID}}-submariner-gw-{{.UUID}}
     spec:
       metadata:
         labels:
@@ -65,12 +65,11 @@ spec:
                 name: {{.InfraID}}-nodes
                 tags: openshiftClusterID={{.InfraID}}
           securityGroups:
-          - filter: {}
-            name: {{.InfraID}}-worker
-          - filter: {}
-            name: {{.InfraID}}-submariner-gw-sg
-          - filter: {}
-            name: {{.InfraID}}-submariner-internal-sg
+          - name: {{.InfraID}}-worker
+          {{- if .UseSubmarinerInternalSG }}
+          - name: {{.InfraID}}-submariner-internal-sg
+          {{- end }}
+          - name: {{.InfraID}}-submariner-gw-sg
           serverMetadata:
             Name: {{.InfraID}}-worker
             openshiftClusterID: {{.InfraID}}


### PR DESCRIPTION
Backport of #671 on release-0.14.

#671: Skip adding internal Security group in machineset

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.