### PR TITLE
Automated backport of #722: Add AirGapped flag to GatewayDeployInput

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -48,6 +48,9 @@ type GatewayDeployInput struct {
 
 	// Use service of type LoadBalancer to deploy Submariner
 	UseLoadBalancer bool
+
+	// Specifies if the underlying deployment is air-gapped.
+	AirGapped bool
 }
 
 // GatewayDeployer will deploy and cleanup dedicated gateways according to the requested policy.

--- a/pkg/azure/gw-machineset.go
+++ b/pkg/azure/gw-machineset.go
@@ -71,7 +71,7 @@ spec:
             managedDisk:
               storageAccountType: Premium_LRS
             osType: Linux
-          publicIP: true
+          publicIP: {{.PublicIP}}
           publicLoadBalancer: ""
           resourceGroup: {{.InfraID}}-rg
           sshPrivateKey: ""

--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -21,6 +21,7 @@ package azure
 import (
 	"bytes"
 	"context"
+	"strconv"
 	"text/template"
 	"time"
 
@@ -130,7 +131,7 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 			return errors.Wrap(imageErr, "error retrieving worker node image")
 		}
 
-		err = d.deployDedicatedGWNode(machineSets, gatewayNodesToDeploy, image, status)
+		err = d.deployDedicatedGWNode(machineSets, gatewayNodesToDeploy, input.AirGapped, image, status)
 	} else {
 		err = d.tagExistingNode(nsgClient, nwClient, pubIPClient, gatewayNodesToDeploy, status)
 	}
@@ -143,7 +144,7 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 }
 
 func (d *ocpGatewayDeployer) deployDedicatedGWNode(gwNodes []unstructured.Unstructured, gatewayNodesToDeploy int,
-	image string, status reporter.Interface,
+	airGapped bool, image string, status reporter.Interface,
 ) error {
 	az, err := d.getAvailabilityZones(gwNodes)
 	if err != nil || az.Len() == 0 {
@@ -153,7 +154,7 @@ func (d *ocpGatewayDeployer) deployDedicatedGWNode(gwNodes []unstructured.Unstru
 	for _, zone := range az.UnsortedList() {
 		status.Start("Deploying dedicated gateway node")
 
-		err := d.deployGateway(zone, image)
+		err := d.deployGateway(zone, image, airGapped)
 		if err != nil {
 			return status.Error(err, "error deploying gateway for zone %q", zone)
 		}
@@ -223,9 +224,10 @@ type machineSetConfig struct {
 	InstanceType string
 	Region       string
 	Image        string
+	PublicIP     string
 }
 
-func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone, image string) ([]byte, error) {
+func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone, image string, airGapped bool) ([]byte, error) {
 	var buf bytes.Buffer
 
 	tpl, err := template.New("").Parse(machineSetYAML)
@@ -240,6 +242,7 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone, image string) ([]byte, 
 		Region:       d.azure.Region,
 		AZ:           zone,
 		Image:        image,
+		PublicIP:     strconv.FormatBool(!airGapped),
 	}
 
 	err = tpl.Execute(&buf, tplVars)
@@ -250,8 +253,8 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone, image string) ([]byte, 
 	return buf.Bytes(), nil
 }
 
-func (d *ocpGatewayDeployer) initMachineSet(name, zone, image string) (*unstructured.Unstructured, error) {
-	gatewayYAML, err := d.loadGatewayYAML(name, zone, image)
+func (d *ocpGatewayDeployer) initMachineSet(name, zone, image string, airGapped bool) (*unstructured.Unstructured, error) {
+	gatewayYAML, err := d.loadGatewayYAML(name, zone, image, airGapped)
 	if err != nil {
 		return nil, err
 	}
@@ -268,8 +271,8 @@ func (d *ocpGatewayDeployer) initMachineSet(name, zone, image string) (*unstruct
 	return machineSet, nil
 }
 
-func (d *ocpGatewayDeployer) deployGateway(zone, image string) error {
-	machineSet, err := d.initMachineSet(MachineName(d.azure.Region), zone, image)
+func (d *ocpGatewayDeployer) deployGateway(zone, image string, airGapped bool) error {
+	machineSet, err := d.initMachineSet(MachineName(d.azure.Region), zone, image, airGapped)
 	if err != nil {
 		return err
 	}

--- a/pkg/azure/ocpgwdeployer_internal_test.go
+++ b/pkg/azure/ocpgwdeployer_internal_test.go
@@ -1,0 +1,94 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/util"
+	ocpFake "github.com/submariner-io/cloud-prepare/pkg/ocp/fake"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("OCP Gateway Deployer", func() {
+	const (
+		infraID      = "test-infraID"
+		region       = "east"
+		image        = "test-image"
+		zone         = "east-zone"
+		instanceType = "large"
+	)
+
+	var (
+		mockCtrl   *gomock.Controller
+		msDeployer *ocpFake.MockMachineSetDeployer
+		gwDeployer *ocpGatewayDeployer
+		machineSet *unstructured.Unstructured
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		msDeployer = ocpFake.NewMockMachineSetDeployer(mockCtrl)
+
+		info := &CloudInfo{
+			InfraID: infraID,
+			Region:  region,
+		}
+
+		gwp, err := NewOcpGatewayDeployer(info, NewCloud(info), msDeployer, instanceType, true)
+		Expect(err).To(Succeed())
+
+		gwDeployer = gwp.(*ocpGatewayDeployer)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Describe("deployGateway", func() {
+		JustBeforeEach(func() {
+			msDeployer.EXPECT().Deploy(gomock.Any()).DoAndReturn(func(ms *unstructured.Unstructured) error {
+				machineSet = ms
+				return nil
+			}).AnyTimes()
+		})
+
+		It("should deploy the correct MachineSet", func() {
+			Expect(gwDeployer.deployGateway(zone, image, false)).To(Succeed())
+
+			Expect(machineSet).ToNot(BeNil())
+			Expect(machineSet.GetLabels()).To(HaveKeyWithValue("machine.openshift.io/cluster-api-cluster", infraID))
+			Expect(util.GetNestedField(machineSet, "metadata", "name")).To(HavePrefix(submarinerGatewayGW + region))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "metadata", "labels")).
+				To(HaveKeyWithValue("submariner.io/gateway", "true"))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "image", "resourceID")).To(Equal(image))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "location")).To(Equal(region))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "zone")).To(Equal(zone))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "vmSize")).To(Equal(instanceType))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "publicIP")).To(BeTrue())
+
+			machineSet = nil
+			Expect(gwDeployer.deployGateway(zone, image, true)).To(Succeed())
+
+			Expect(machineSet).ToNot(BeNil())
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "publicIP")).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
Backport of #722 on release-0.15.

#722: Add AirGapped flag to GatewayDeployInput

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.