### PR TITLE
Automated backport of #722: Add AirGapped flag to GatewayDeployInput

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/gophercloud/gophercloud v1.0.0
 	github.com/onsi/ginkgo v1.16.5
+	github.com/onsi/ginkgo/v2 v2.3.0
 	github.com/onsi/gomega v1.22.1
 	github.com/pkg/errors v0.9.1
 	github.com/submariner-io/admiral v0.14.5

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,7 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.3.0 h1:kUMoxMoQG3ogk/QWyKh3zibV7BKZ+xBpWil1cTylVqc=
+github.com/onsi/ginkgo/v2 v2.3.0/go.mod h1:Eew0uilEqZmIEZr8JrvYlvOM7Rr6xzTmMV8AyFNU9d0=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -53,6 +53,9 @@ type GatewayDeployInput struct {
 
 	// Use service of type LoadBalancer to deploy Submariner
 	UseLoadBalancer bool
+
+	// Specifies if the underlying deployment is air-gapped.
+	AirGapped bool
 }
 
 // GatewayDeployer will deploy and cleanup dedicated gateways according to the requested policy.

--- a/pkg/azure/gw-machineset.go
+++ b/pkg/azure/gw-machineset.go
@@ -70,7 +70,7 @@ spec:
             managedDisk:
               storageAccountType: Premium_LRS
             osType: Linux
-          publicIP: true
+          publicIP: {{.PublicIP}}
           publicLoadBalancer: ""
           resourceGroup: {{.InfraID}}-rg
           sshPrivateKey: ""

--- a/pkg/azure/ocpgwdeployer_internal_test.go
+++ b/pkg/azure/ocpgwdeployer_internal_test.go
@@ -1,0 +1,94 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/util"
+	ocpFake "github.com/submariner-io/cloud-prepare/pkg/ocp/fake"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("OCP Gateway Deployer", func() {
+	const (
+		infraID      = "test-infraID"
+		region       = "east"
+		image        = "test-image"
+		zone         = "east-zone"
+		instanceType = "large"
+	)
+
+	var (
+		mockCtrl   *gomock.Controller
+		msDeployer *ocpFake.MockMachineSetDeployer
+		gwDeployer *ocpGatewayDeployer
+		machineSet *unstructured.Unstructured
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		msDeployer = ocpFake.NewMockMachineSetDeployer(mockCtrl)
+
+		info := &CloudInfo{
+			InfraID: infraID,
+			Region:  region,
+		}
+
+		gwp, err := NewOcpGatewayDeployer(info, NewCloud(info), msDeployer, instanceType, true)
+		Expect(err).To(Succeed())
+
+		gwDeployer = gwp.(*ocpGatewayDeployer)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Describe("deployGateway", func() {
+		JustBeforeEach(func() {
+			msDeployer.EXPECT().Deploy(gomock.Any()).DoAndReturn(func(ms *unstructured.Unstructured) error {
+				machineSet = ms
+				return nil
+			}).AnyTimes()
+		})
+
+		It("should deploy the correct MachineSet", func() {
+			Expect(gwDeployer.deployGateway(zone, image, false)).To(Succeed())
+
+			Expect(machineSet).ToNot(BeNil())
+			Expect(machineSet.GetLabels()).To(HaveKeyWithValue("machine.openshift.io/cluster-api-cluster", infraID))
+			Expect(util.GetNestedField(machineSet, "metadata", "name")).To(HavePrefix(submarinerGatewayGW + region))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "metadata", "labels")).
+				To(HaveKeyWithValue("submariner.io/gateway", "true"))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "image", "resourceID")).To(Equal(image))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "location")).To(Equal(region))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "zone")).To(Equal(zone))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "vmSize")).To(Equal(instanceType))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "publicIP")).To(BeTrue())
+
+			machineSet = nil
+			Expect(gwDeployer.deployGateway(zone, image, true)).To(Succeed())
+
+			Expect(machineSet).ToNot(BeNil())
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "publicIP")).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
Backport of #722 on release-0.14.

#722: Add AirGapped flag to GatewayDeployInput

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.