### PR TITLE
Automated backport of #881: Add Makefile.shipyard to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ output/
 vendor/
 .dapper
 Makefile.dapper
+Makefile.shipyard
 /Dockerfile.*
 .idea
 *.coverprofile


### PR DESCRIPTION
Backport of #881 on release-0.17.

#881: Add Makefile.shipyard to .gitignore

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.