### PR TITLE
Only fail builds for high+ vulns

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           path: "."
           fail-build: true
-          severity-cutoff: negligible
+          severity-cutoff: high
       - name: Show Anchore scan SARIF report
         if: always()
         run: cat ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
Since the vulnerability scan doesn't distinguish between vulnerabilities added by the PR and those coming from vulnerability updates, PRs are regularly blocked because of unrelated vulnerabilities. Arguably this is desirable for important vulnerabilities since it forces them to be handled; but other vulnerabilities shouldn't block PRs.

This changes the fail threshold to high, so that only vulnerabilities with severity high or critical will block the build.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
