### PR TITLE
Fix linting error with golangci-lint v1.57.1

### DIFF
--- a/pkg/k8s/k8siface.go
+++ b/pkg/k8s/k8siface.go
@@ -71,7 +71,6 @@ func (k *k8sIface) ListGatewayNodes() (*v1.NodeList, error) {
 }
 
 func (k *k8sIface) updateLabel(nodeName string, mutate func(existing *v1.Node)) error {
-	//nolint:wrapcheck // Let the caller wrap these errors.
 	client := &resource.InterfaceFuncs[*v1.Node]{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (*v1.Node, error) {
 			return k.clientSet.CoreV1().Nodes().Get(ctx, name, options)


### PR DESCRIPTION
`wrapcheck` no longer flags anonymous functions.
