### PR TITLE
Automated backport of #949: Fix AWS cloud prepare to support new naming convention

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -99,8 +99,12 @@ func (ac *awsCloud) setSuffixes(vpcID string) error {
 	}
 
 	publicSubnets, err := ac.findPublicSubnets(vpcID, ac.filterByName("{infraID}*-public-{region}*"))
-	if err != nil || len(publicSubnets) == 0 {
+	if err != nil {
 		return errors.Wrapf(err, "unable to find the public subnet")
+	}
+
+	if len(publicSubnets) == 0 {
+		return errors.New("no public subnet found")
 	}
 
 	pattern := fmt.Sprintf(`%s.*-subnet-public-%s.*`, regexp.QuoteMeta(ac.infraID), regexp.QuoteMeta(ac.region))

--- a/pkg/aws/aws_cloud_test.go
+++ b/pkg/aws/aws_cloud_test.go
@@ -40,6 +40,8 @@ func testOpenPorts() {
 
 	JustBeforeEach(func() {
 		t.expectDescribeVpcs(t.vpcID)
+		t.expectDescribeVpcsSigs(t.vpcID)
+		t.expectDescribePublicSubnets(t.subnets...)
 
 		retError = t.cloud.OpenPorts([]api.PortSpec{
 			{
@@ -87,6 +89,7 @@ func testOpenPorts() {
 	When("authorize security group ingress validation fails", func() {
 		BeforeEach(func() {
 			t.expectDescribeVpcs(vpcID)
+			t.expectDescribePublicSubnets(t.subnets...)
 			t.expectValidateAuthorizeSecurityGroupIngress(errors.New("mock error"))
 		})
 
@@ -114,6 +117,9 @@ func testClosePorts() {
 
 	JustBeforeEach(func() {
 		t.expectDescribeVpcs(t.vpcID)
+		t.expectDescribePublicSubnets(t.subnets...)
+		t.expectDescribeVpcsSigs(t.vpcID)
+		t.expectDescribePublicSubnetsSigs(t.subnets...)
 
 		retError = t.cloud.ClosePorts(reporter.Stdout())
 	})

--- a/pkg/aws/ec2helpers.go
+++ b/pkg/aws/ec2helpers.go
@@ -73,6 +73,9 @@ func (ac *awsCloud) filterByName(name string) types.Filter {
 	return ec2Filter("tag:Name", ac.withAWSInfo(name))
 }
 
-func (ac *awsCloud) filterByCurrentCluster() types.Filter {
-	return ec2Filter(ac.withAWSInfo("tag:kubernetes.io/cluster/{infraID}"), "owned")
+func (ac *awsCloud) filterByCurrentCluster() []types.Filter {
+	return []types.Filter{
+		ec2Filter(ac.withAWSInfo("tag:kubernetes.io/cluster/{infraID}"), "owned"),
+		ec2Filter(ac.withAWSInfo("tag:sigs.k8s.io/cluster-api-provider-aws/cluster/{infraID}"), "owned"),
+	}
 }

--- a/pkg/aws/gw-machineset.go
+++ b/pkg/aws/gw-machineset.go
@@ -65,7 +65,7 @@ spec:
             - filters:
                 - name: tag:Name
                   values:
-                    - {{.InfraID}}-worker-sg
+                    - {{.InfraID}}{{.NodeSGSuffix}}
                     - {{.SecurityGroup}}
           subnet:
             filters:

--- a/pkg/aws/gw-machineset.yaml.template
+++ b/pkg/aws/gw-machineset.yaml.template
@@ -46,7 +46,7 @@ spec:
             - filters:
                 - name: tag:Name
                   values:
-                    - {{.InfraID}}-worker-sg
+                    - {{.InfraID}}{{.NodeSGSuffix}}
                     - {{.SecurityGroup}}
           subnet:
             filters:

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -69,9 +69,14 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 
 	status.Success(messageRetrievedVPCID, vpcID)
 
+	err = d.aws.setSuffixes(vpcID)
+	if err != nil {
+		return status.Error(err, "unable to retrieve the security group names")
+	}
+
 	status.Start(messageValidatePrerequisites)
 
-	publicSubnets, err := d.aws.findPublicSubnets(vpcID, d.aws.filterByName("{infraID}-public-{region}*"))
+	publicSubnets, err := d.aws.findPublicSubnets(vpcID, d.aws.filterByName("{infraID}*-public-{region}*"))
 	if err != nil {
 		return status.Error(err, "unable to find public subnets")
 	}
@@ -198,21 +203,32 @@ type machineSetConfig struct {
 	Region        string
 	SecurityGroup string
 	PublicSubnet  string
+	NodeSGSuffix  string
 }
 
 func (d *ocpGatewayDeployer) findAMIID(vpcID string) (string, error) {
-	result, err := d.aws.client.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
-		Filters: []types.Filter{
-			ec2Filter("vpc-id", vpcID),
-			d.aws.filterByName("{infraID}-worker*"),
-			d.aws.filterByCurrentCluster(),
-		},
-	})
-	if err != nil {
-		return "", errors.Wrap(err, "error describing AWS instances")
+	ownedFilters := d.aws.filterByCurrentCluster()
+	var err error
+	var result *ec2.DescribeInstancesOutput
+
+	for i := range ownedFilters {
+		result, err = d.aws.client.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
+			Filters: []types.Filter{
+				ec2Filter("vpc-id", vpcID),
+				d.aws.filterByName("{infraID}-worker*"),
+				ownedFilters[i],
+			},
+		})
+		if err != nil {
+			continue
+		}
+
+		if len(result.Reservations) != 0 {
+			break
+		}
 	}
 
-	if len(result.Reservations) == 0 {
+	if err != nil || len(result.Reservations) == 0 {
 		return "", newNotFoundError("reservations")
 	}
 
@@ -245,6 +261,7 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(gatewaySecurityGroup, amiID string,
 		Region:        d.aws.region,
 		SecurityGroup: gatewaySecurityGroup,
 		PublicSubnet:  extractName(publicSubnet.Tags),
+		NodeSGSuffix:  d.aws.nodeSGSuffix,
 	}
 
 	err = tpl.Execute(&buf, tplVars)
@@ -297,6 +314,11 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 	}
 
 	status.Success(messageRetrievedVPCID, vpcID)
+
+	err = d.aws.setSuffixes(vpcID)
+	if err != nil {
+		return status.Error(err, "unable to retrieve the security group names")
+	}
 
 	status.Start(messageValidatePrerequisites)
 

--- a/pkg/aws/ocpgwdeployer_test.go
+++ b/pkg/aws/ocpgwdeployer_test.go
@@ -283,6 +283,9 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 		t.expectDescribeSecurityGroups(gatewaySGName, t.gatewayGroupID)
 		t.expectDescribeInstances(instanceImageID)
 		t.expectDescribeSecurityGroups(workerSGName, workerGroupID)
+		t.expectDescribePublicSubnets(t.subnets...)
+		t.expectDescribeVpcsSigs(t.vpcID)
+		t.expectDescribePublicSubnetsSigs(t.subnets...)
 
 		var err error
 

--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -97,12 +97,12 @@ func (ac *awsCloud) createClusterSGRule(srcGroup, destGroup *string, port uint16
 }
 
 func (ac *awsCloud) allowPortInCluster(vpcID string, port uint16, protocol string) error {
-	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}-worker-sg")
+	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}"+ac.nodeSGSuffix)
 	if err != nil {
 		return err
 	}
 
-	masterGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}-master-sg")
+	masterGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}"+ac.controlPlaneSGSuffix)
 	if err != nil {
 		return err
 	}
@@ -219,12 +219,12 @@ func (ac *awsCloud) deleteGatewaySG(vpcID string) error {
 }
 
 func (ac *awsCloud) revokePortsInCluster(vpcID string) error {
-	workerGroup, err := ac.getSecurityGroup(vpcID, "{infraID}-worker-sg")
+	workerGroup, err := ac.getSecurityGroup(vpcID, "{infraID}"+ac.nodeSGSuffix)
 	if err != nil {
 		return err
 	}
 
-	masterGroup, err := ac.getSecurityGroup(vpcID, "{infraID}-master-sg")
+	masterGroup, err := ac.getSecurityGroup(vpcID, "{infraID}"+ac.controlPlaneSGSuffix)
 	if err != nil {
 		return err
 	}

--- a/pkg/aws/validations.go
+++ b/pkg/aws/validations.go
@@ -54,7 +54,7 @@ func (ac *awsCloud) validateCreateSecGroup(vpcID string) error {
 }
 
 func (ac *awsCloud) validateCreateSecGroupRule(vpcID string) error {
-	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}-worker-sg")
+	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}"+ac.nodeSGSuffix)
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func (ac *awsCloud) validateDescribeInstanceTypeOfferings() error {
 }
 
 func (ac *awsCloud) validateDeleteSecGroup(vpcID string) error {
-	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}-worker-sg")
+	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}"+ac.nodeSGSuffix)
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func (ac *awsCloud) validateDeleteSecGroup(vpcID string) error {
 }
 
 func (ac *awsCloud) validateDeleteSecGroupRule(vpcID string) error {
-	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}-worker-sg")
+	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}"+ac.nodeSGSuffix)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport of #949 on release-0.18.

#949: Fix AWS cloud prepare to support new naming convention

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.