### PR TITLE
Remove TODOs re: use template.ParseFiles

### DIFF
--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -246,8 +246,6 @@ func (d *ocpGatewayDeployer) findAMIID(vpcID string) (string, error) {
 func (d *ocpGatewayDeployer) loadGatewayYAML(gatewaySecurityGroup, amiID string, publicSubnet *types.Subnet) ([]byte, error) {
 	var buf bytes.Buffer
 
-	// TODO: Not working properly, but we should revisit this as it makes more sense
-	// tpl, err := template.ParseFiles("pkg/aws/gw-machineset.yaml.template")
 	tpl, err := template.New("").Parse(machineSetYAML)
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing machine set YAML")

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -171,8 +171,6 @@ type machineSetConfig struct {
 func (d *ocpGatewayDeployer) loadGatewayYAML(zone, image string) ([]byte, error) {
 	var buf bytes.Buffer
 
-	// TODO: Not working properly, but we should revisit this as it makes more sense
-	// tpl, err := template.ParseFiles("pkg/aws/gw-machineset.yaml.template")
 	tpl, err := template.New("").Parse(machineSetYAML)
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing machine set YAML")

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -73,8 +73,6 @@ type machineSetConfig struct {
 func (d *ocpGatewayDeployer) loadGatewayYAML(uuidGW, image string, useInternalSG bool) ([]byte, error) {
 	var buf bytes.Buffer
 
-	// TODO: Not working properly, but we should revisit this as it makes more sense
-	// tpl, err := template.ParseFiles("pkg/aws/gw-machineset.yaml.template")
 	tpl, err := template.New("").Parse(machineSetYAML)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create machine set template")


### PR DESCRIPTION
"_Not working properly, but we should revisit this as it makes more sense_"

This was never revisited and I don't see a compelling reason to do so since the actual code using string YAML has been working fine.