### PR TITLE
Automated backport of #1007: Add custom vpc support in AWS cloud prepare

### DIFF
--- a/pkg/aws/aws_cloud_test.go
+++ b/pkg/aws/aws_cloud_test.go
@@ -40,6 +40,7 @@ func testOpenPorts() {
 
 	JustBeforeEach(func() {
 		t.expectDescribeVpcs(t.vpcID)
+		t.expectDescribePublicSubnets(t.subnets...)
 
 		retError = t.cloud.OpenPorts([]api.PortSpec{
 			{
@@ -114,6 +115,8 @@ func testClosePorts() {
 
 	JustBeforeEach(func() {
 		t.expectDescribeVpcs(t.vpcID)
+		t.expectDescribePublicSubnets(t.subnets...)
+		t.expectDescribePublicSubnetsSigs(t.subnets...)
 
 		retError = t.cloud.ClosePorts(reporter.Stdout())
 	})

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -69,11 +69,35 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 
 	status.Success(messageRetrievedVPCID, vpcID)
 
+	if _, found := d.aws.cloudConfig[VPCIDKey]; !found {
+		err = d.aws.setSuffixes(vpcID)
+		if err != nil {
+			return status.Error(err, "unable to retrieve the security group names")
+		}
+	}
+
 	status.Start(messageValidatePrerequisites)
 
-	publicSubnets, err := d.aws.findPublicSubnets(vpcID, d.aws.filterByName("{infraID}-public-{region}*"))
-	if err != nil {
-		return status.Error(err, "unable to find public subnets")
+	var publicSubnets []types.Subnet
+
+	if subnets, exists := d.aws.cloudConfig[PublicSubnetListKey]; exists {
+		if subnetIDs, ok := subnets.([]string); ok && len(subnetIDs) > 0 {
+			for _, id := range subnetIDs {
+				subnet, err := d.aws.getSubnetByID(id)
+				if err != nil {
+					return errors.Wrapf(err, "unable to find subnet with ID %s", id)
+				}
+
+				publicSubnets = append(publicSubnets, *subnet)
+			}
+		} else {
+			return errors.New("Subnet IDs must be a valid non-empty slice of strings")
+		}
+	} else {
+		publicSubnets, err = d.aws.findPublicSubnets(vpcID, d.aws.filterByName("{infraID}*-public-{region}*"))
+		if err != nil {
+			return status.Error(err, "unable to find public subnets")
+		}
 	}
 
 	err = d.validateDeployPrerequisites(vpcID, input, publicSubnets)
@@ -92,9 +116,15 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 
 	status.Success("Created Submariner gateway security group %s", gatewaySG)
 
+	return d.processSubnets(vpcID, gatewaySG, publicSubnets, input, status)
+}
+
+func (d *ocpGatewayDeployer) processSubnets(vpcID, gatewaySG string, publicSubnets []types.Subnet,
+	input api.GatewayDeployInput, status reporter.Interface,
+) error {
 	subnets, err := d.aws.getSubnetsSupportingInstanceType(publicSubnets, d.instanceType)
 	if err != nil {
-		return status.Error(err, "unable to create security group")
+		return status.Error(err, "unable to get subnets supporting instance type")
 	}
 
 	taggedSubnets, _ := filterSubnets(subnets, func(subnet *types.Subnet) (bool, error) {
@@ -298,6 +328,13 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 
 	status.Success(messageRetrievedVPCID, vpcID)
 
+	if _, found := d.aws.cloudConfig[VPCIDKey]; !found {
+		err = d.aws.setSuffixes(vpcID)
+		if err != nil {
+			return status.Error(err, "unable to retrieve the security group names")
+		}
+	}
+
 	status.Start(messageValidatePrerequisites)
 
 	err = d.validateCleanupPrerequisites(vpcID)
@@ -307,13 +344,30 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 
 	status.Success(messageValidatedPrerequisites)
 
-	subnets, err := d.aws.getTaggedPublicSubnets(vpcID)
-	if err != nil {
-		return err
+	var publicSubnets []types.Subnet
+
+	if subnets, exists := d.aws.cloudConfig[PublicSubnetListKey]; exists {
+		if subnetIDs, ok := subnets.([]string); ok && len(subnetIDs) > 0 {
+			for _, id := range subnetIDs {
+				subnet, err := d.aws.getSubnetByID(id)
+				if err != nil {
+					return errors.Wrapf(err, "unable to find subnet with ID %s", id)
+				}
+
+				publicSubnets = append(publicSubnets, *subnet)
+			}
+		} else {
+			return errors.New("Subnet IDs must be a valid non-empty slice of strings")
+		}
+	} else {
+		publicSubnets, err = d.aws.getTaggedPublicSubnets(vpcID)
+		if err != nil {
+			return err
+		}
 	}
 
-	for i := range subnets {
-		subnet := &subnets[i]
+	for i := range publicSubnets {
+		subnet := &publicSubnets[i]
 		subnetName := extractName(subnet.Tags)
 
 		status.Start("Removing gateway node for public subnet %s", subnetName)

--- a/pkg/aws/ocpgwdeployer_test.go
+++ b/pkg/aws/ocpgwdeployer_test.go
@@ -282,7 +282,9 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 		t.expectDescribeVpcs(t.vpcID)
 		t.expectDescribeSecurityGroups(infraID+"-submariner-gw-sg", t.gatewayGroupID)
 		t.expectDescribeInstances(instanceImageID)
-		t.expectDescribeSecurityGroups(infraID+"-worker-sg", workerGroupID)
+		t.expectDescribeSecurityGroups(workerSGName, workerGroupID)
+		t.expectDescribePublicSubnets(t.subnets...)
+		t.expectDescribePublicSubnetsSigs(t.subnets...)
 
 		var err error
 

--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -35,13 +35,28 @@ import (
 
 const internalTraffic = "Internal Submariner traffic"
 
-func (ac *awsCloud) getSecurityGroupID(vpcID, name string) (*string, error) {
+func (ac *awsCloud) getSecurityGroupName(vpcID, name string) (*string, error) {
 	group, err := ac.getSecurityGroup(vpcID, name)
 	if err != nil {
 		return nil, err
 	}
 
 	return group.GroupId, nil
+}
+
+func (ac *awsCloud) getSecurityGroupByID(groupID string) (types.SecurityGroup, error) {
+	output, err := ac.client.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{
+		GroupIds: []string{groupID},
+	})
+	if err != nil {
+		return types.SecurityGroup{}, errors.Wrapf(err, "unable to describe security group %s", groupID)
+	}
+
+	if len(output.SecurityGroups) == 0 {
+		return types.SecurityGroup{}, errors.New("security group not found")
+	}
+
+	return output.SecurityGroups[0], nil
 }
 
 func (ac *awsCloud) getSecurityGroup(vpcID, name string) (types.SecurityGroup, error) {
@@ -97,14 +112,37 @@ func (ac *awsCloud) createClusterSGRule(srcGroup, destGroup *string, port uint16
 }
 
 func (ac *awsCloud) allowPortInCluster(vpcID string, port uint16, protocol string) error {
-	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}-worker-sg")
-	if err != nil {
-		return err
+	var workerGroupID, controlPlaneGroupID *string
+	var err error
+
+	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
+		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
+			workerGroupID = &workerGroupIDStr
+		} else {
+			return errors.New("Worker Security Group ID must be a valid non-empty string")
+		}
+	} else {
+		workerGroupName := withInfraIDPrefix(ac.nodeSGSuffix)
+
+		workerGroupID, err = ac.getSecurityGroupName(vpcID, workerGroupName)
+		if err != nil {
+			return err
+		}
 	}
 
-	masterGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}-master-sg")
-	if err != nil {
-		return err
+	if id, exists := ac.cloudConfig[ControlPlaneSecurityGroupIDKey]; exists {
+		if controlPlaneGroupIDStr, ok := id.(string); ok && controlPlaneGroupIDStr != "" {
+			controlPlaneGroupID = &controlPlaneGroupIDStr
+		} else {
+			return errors.New("Control Plane Security Group ID must be a valid non-empty string")
+		}
+	} else {
+		controlPlaneGroupName := withInfraIDPrefix(ac.controlPlaneSGSuffix)
+
+		controlPlaneGroupID, err = ac.getSecurityGroupName(vpcID, controlPlaneGroupName)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = ac.createClusterSGRule(workerGroupID, workerGroupID, port, protocol, fmt.Sprintf("%s between the workers", internalTraffic))
@@ -112,12 +150,14 @@ func (ac *awsCloud) allowPortInCluster(vpcID string, port uint16, protocol strin
 		return err
 	}
 
-	err = ac.createClusterSGRule(workerGroupID, masterGroupID, port, protocol, fmt.Sprintf("%s from worker to master nodes", internalTraffic))
+	err = ac.createClusterSGRule(workerGroupID, controlPlaneGroupID, port, protocol,
+		fmt.Sprintf("%s from worker to control plane nodes", internalTraffic))
 	if err != nil {
 		return err
 	}
 
-	return ac.createClusterSGRule(masterGroupID, workerGroupID, port, protocol, fmt.Sprintf("%s from master to worker nodes", internalTraffic))
+	return ac.createClusterSGRule(controlPlaneGroupID, workerGroupID, port, protocol,
+		fmt.Sprintf("%s from control plane to worker nodes", internalTraffic))
 }
 
 func (ac *awsCloud) createPublicSGRule(groupID *string, port uint16, protocol, description string) error {
@@ -141,7 +181,7 @@ func (ac *awsCloud) createPublicSGRule(groupID *string, port uint16, protocol, d
 func (ac *awsCloud) createGatewaySG(vpcID string, ports []api.PortSpec) (string, error) {
 	groupName := ac.withAWSInfo("{infraID}-submariner-gw-sg")
 
-	gatewayGroupID, err := ac.getSecurityGroupID(vpcID, groupName)
+	gatewayGroupID, err := ac.getSecurityGroupName(vpcID, groupName)
 	if err != nil {
 		if !isNotFoundError(err) {
 			return "", err
@@ -187,7 +227,7 @@ func gatewayDeletionRetriable(err error) bool {
 func (ac *awsCloud) deleteGatewaySG(vpcID string) error {
 	groupName := ac.withAWSInfo("{infraID}-submariner-gw-sg")
 
-	gatewayGroupID, err := ac.getSecurityGroupID(vpcID, groupName)
+	gatewayGroupID, err := ac.getSecurityGroupName(vpcID, groupName)
 	if err != nil {
 		if isNotFoundError(err) {
 			return nil
@@ -219,14 +259,43 @@ func (ac *awsCloud) deleteGatewaySG(vpcID string) error {
 }
 
 func (ac *awsCloud) revokePortsInCluster(vpcID string) error {
-	workerGroup, err := ac.getSecurityGroup(vpcID, "{infraID}-worker-sg")
-	if err != nil {
-		return err
+	var workerGroup, controlPlaneGroup types.SecurityGroup
+	var err error
+
+	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
+		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
+			workerGroup, err = ac.getSecurityGroupByID(workerGroupIDStr)
+			if err != nil {
+				return errors.Wrap(err, "unable to get Worker Security Group by ID")
+			}
+		} else {
+			return errors.New("Worker Security Group ID must be a valid non-empty string")
+		}
+	} else {
+		workerGroupName := withInfraIDPrefix(ac.nodeSGSuffix)
+
+		workerGroup, err = ac.getSecurityGroup(vpcID, workerGroupName)
+		if err != nil {
+			return err
+		}
 	}
 
-	masterGroup, err := ac.getSecurityGroup(vpcID, "{infraID}-master-sg")
-	if err != nil {
-		return err
+	if id, exists := ac.cloudConfig[ControlPlaneSecurityGroupIDKey]; exists {
+		if controlPlaneGroupIDStr, ok := id.(string); ok && controlPlaneGroupIDStr != "" {
+			controlPlaneGroup, err = ac.getSecurityGroupByID(controlPlaneGroupIDStr)
+			if err != nil {
+				return errors.Wrap(err, "unable to get Control Plane Security Group by ID")
+			}
+		} else {
+			return errors.New("Control Plane Security Group ID must be a valid non-empty string")
+		}
+	} else {
+		controlPlaneGroupName := withInfraIDPrefix(ac.controlPlaneSGSuffix)
+
+		controlPlaneGroup, err = ac.getSecurityGroup(vpcID, controlPlaneGroupName)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = ac.revokePortsFromGroup(&workerGroup)
@@ -234,7 +303,7 @@ func (ac *awsCloud) revokePortsInCluster(vpcID string) error {
 		return err
 	}
 
-	return ac.revokePortsFromGroup(&masterGroup)
+	return ac.revokePortsFromGroup(&controlPlaneGroup)
 }
 
 func (ac *awsCloud) revokePortsFromGroup(group *types.SecurityGroup) error {

--- a/pkg/aws/subnets.go
+++ b/pkg/aws/subnets.go
@@ -113,3 +113,18 @@ func (ac *awsCloud) untagPublicSubnet(subnetID *string) error {
 
 	return errors.Wrap(err, "error deleting AWS tag")
 }
+
+func (ac *awsCloud) getSubnetByID(subnetID string) (*types.Subnet, error) {
+	output, err := ac.client.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{
+		SubnetIds: []string{subnetID},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to describe subnet %s", subnetID)
+	}
+
+	if len(output.Subnets) == 0 {
+		return nil, errors.New("subnet not found")
+	}
+
+	return &output.Subnets[0], nil
+}

--- a/pkg/aws/validations.go
+++ b/pkg/aws/validations.go
@@ -54,9 +54,21 @@ func (ac *awsCloud) validateCreateSecGroup(vpcID string) error {
 }
 
 func (ac *awsCloud) validateCreateSecGroupRule(vpcID string) error {
-	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}-worker-sg")
-	if err != nil {
-		return err
+	var workerGroupID *string
+
+	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
+		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
+			workerGroupID = &workerGroupIDStr
+		} else {
+			return errors.New("Worker Security Group ID must be a valid non-empty string")
+		}
+	} else {
+		var err error
+
+		workerGroupID, err = ac.getSecurityGroupName(vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
+		if err != nil {
+			return err
+		}
 	}
 
 	input := &ec2.AuthorizeSecurityGroupIngressInput{
@@ -64,7 +76,7 @@ func (ac *awsCloud) validateCreateSecGroupRule(vpcID string) error {
 		GroupId: workerGroupID,
 	}
 
-	_, err = ac.client.AuthorizeSecurityGroupIngress(context.TODO(), input)
+	_, err := ac.client.AuthorizeSecurityGroupIngress(context.TODO(), input)
 
 	return determinePermissionError(err, "authorize security group ingress")
 }
@@ -90,9 +102,21 @@ func (ac *awsCloud) validateDescribeInstanceTypeOfferings() error {
 }
 
 func (ac *awsCloud) validateDeleteSecGroup(vpcID string) error {
-	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}-worker-sg")
-	if err != nil {
-		return err
+	var workerGroupID *string
+
+	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
+		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
+			workerGroupID = &workerGroupIDStr
+		} else {
+			return errors.New("Worker Security Group ID must be a valid non-empty string")
+		}
+	} else {
+		var err error
+
+		workerGroupID, err = ac.getSecurityGroupName(vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
+		if err != nil {
+			return err
+		}
 	}
 
 	input := &ec2.DeleteSecurityGroupInput{
@@ -100,15 +124,27 @@ func (ac *awsCloud) validateDeleteSecGroup(vpcID string) error {
 		GroupId: workerGroupID,
 	}
 
-	_, err = ac.client.DeleteSecurityGroup(context.TODO(), input)
+	_, err := ac.client.DeleteSecurityGroup(context.TODO(), input)
 
 	return determinePermissionError(err, "delete security group")
 }
 
 func (ac *awsCloud) validateDeleteSecGroupRule(vpcID string) error {
-	workerGroupID, err := ac.getSecurityGroupID(vpcID, "{infraID}-worker-sg")
-	if err != nil {
-		return err
+	var workerGroupID *string
+
+	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
+		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
+			workerGroupID = &workerGroupIDStr
+		} else {
+			return errors.New("Worker Security Group ID must be a valid non-empty string")
+		}
+	} else {
+		var err error
+
+		workerGroupID, err = ac.getSecurityGroupName(vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
+		if err != nil {
+			return err
+		}
 	}
 
 	input := &ec2.RevokeSecurityGroupIngressInput{
@@ -116,7 +152,7 @@ func (ac *awsCloud) validateDeleteSecGroupRule(vpcID string) error {
 		GroupId: workerGroupID,
 	}
 
-	_, err = ac.client.RevokeSecurityGroupIngress(context.TODO(), input)
+	_, err := ac.client.RevokeSecurityGroupIngress(context.TODO(), input)
 
 	return determinePermissionError(err, "revoke security group ingress")
 }


### PR DESCRIPTION
Backport of #1007 on release-0.16.

#1007: Add custom vpc support in AWS cloud prepare

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.