### PR TITLE
Fix worker SG assocation when custom vpc is used

### DIFF
--- a/pkg/aws/gw-machineset.go
+++ b/pkg/aws/gw-machineset.go
@@ -65,7 +65,7 @@ spec:
             - filters:
                 - name: tag:Name
                   values:
-                    - {{.InfraID}}{{.NodeSGSuffix}}
+                    - {{.NodeSG}}
                     - {{.SecurityGroup}}
           subnet:
             filters:

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -228,7 +228,7 @@ type machineSetConfig struct {
 	Region        string
 	SecurityGroup string
 	PublicSubnet  string
-	NodeSGSuffix  string
+	NodeSG        string
 }
 
 func (d *ocpGatewayDeployer) findAMIID(vpcID string) (string, error) {
@@ -284,7 +284,25 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(gatewaySecurityGroup, amiID string,
 		Region:        d.aws.region,
 		SecurityGroup: gatewaySecurityGroup,
 		PublicSubnet:  extractName(publicSubnet.Tags),
-		NodeSGSuffix:  d.aws.nodeSGSuffix,
+	}
+
+	if id, exists := d.aws.cloudConfig[WorkerSecurityGroupIDKey]; exists {
+		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
+			workerSecurityGroup, err := d.aws.getSecurityGroupByID(workerGroupIDStr)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error finding the worker security group with ID %s", workerGroupIDStr)
+			}
+
+			if workerSecurityGroup.GroupName == nil {
+				return nil, errors.Errorf("security group with ID %s has no group name", workerGroupIDStr)
+			}
+
+			tplVars.NodeSG = *workerSecurityGroup.GroupName
+		} else {
+			return nil, errors.New("worker Security Group ID must be a valid non-empty string")
+		}
+	} else {
+		tplVars.NodeSG = d.aws.infraID + d.aws.nodeSGSuffix
 	}
 
 	err = tpl.Execute(&buf, tplVars)


### PR DESCRIPTION
Fix worker SG assocation when custom vpc is used
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
