### PR TITLE
Automated backport of #1010: Fix worker SG assocation when custom vpc is used

### DIFF
--- a/pkg/aws/gw-machineset.go
+++ b/pkg/aws/gw-machineset.go
@@ -65,7 +65,7 @@ spec:
             - filters:
                 - name: tag:Name
                   values:
-                    - {{.InfraID}}-worker-sg
+                    - {{.NodeSG}}
                     - {{.SecurityGroup}}
           subnet:
             filters:

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -228,6 +228,7 @@ type machineSetConfig struct {
 	Region        string
 	SecurityGroup string
 	PublicSubnet  string
+	NodeSG        string
 }
 
 func (d *ocpGatewayDeployer) findAMIID(vpcID string) (string, error) {
@@ -275,6 +276,25 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(gatewaySecurityGroup, amiID string,
 		Region:        d.aws.region,
 		SecurityGroup: gatewaySecurityGroup,
 		PublicSubnet:  extractName(publicSubnet.Tags),
+	}
+
+	if id, exists := d.aws.cloudConfig[WorkerSecurityGroupIDKey]; exists {
+		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
+			workerSecurityGroup, err := d.aws.getSecurityGroupByID(workerGroupIDStr)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error finding the worker security group with ID %s", workerGroupIDStr)
+			}
+
+			if workerSecurityGroup.GroupName == nil {
+				return nil, errors.Errorf("security group with ID %s has no group name", workerGroupIDStr)
+			}
+
+			tplVars.NodeSG = *workerSecurityGroup.GroupName
+		} else {
+			return nil, errors.New("worker Security Group ID must be a valid non-empty string")
+		}
+	} else {
+		tplVars.NodeSG = d.aws.infraID + d.aws.nodeSGSuffix
 	}
 
 	err = tpl.Execute(&buf, tplVars)


### PR DESCRIPTION
Backport of #1010 on release-0.16.

#1010: Fix worker SG assocation when custom vpc is used

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.