### PR TITLE
Automated backport of #1015: Fix worker SG assocation when custom vpc is used

### DIFF
--- a/pkg/aws/gw-machineset.go
+++ b/pkg/aws/gw-machineset.go
@@ -65,7 +65,7 @@ spec:
             - filters:
                 - name: tag:Name
                   values:
-                    - {{.InfraID}}{{.NodeSGSuffix}}
+                    - {{.NodeSG}}
                     - {{.SecurityGroup}}
           subnet:
             filters:


### PR DESCRIPTION
Backport of #1015 on release-0.17.

#1015: Fix worker SG assocation when custom vpc is used

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.