### PR TITLE
Automated backport of #1008: Add custom vpc support in AWS cloud prepare

### DIFF
--- a/pkg/aws/aws_suite_test.go
+++ b/pkg/aws/aws_suite_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/mock"
 	"github.com/submariner-io/cloud-prepare/pkg/aws/client/fake"
+	"go.uber.org/mock/gomock"
 	"k8s.io/utils/ptr"
 )
 


### PR DESCRIPTION
Backport of #1008 on release-0.17.

#1008: Add custom vpc support in AWS cloud prepare

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.