### PR TITLE
Automated backport of #1026: Fix aws cloud prepare failure

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -163,7 +163,9 @@ func (ac *awsCloud) setSuffixes(vpcID string) error {
 			return errors.New("Subnet IDs must be a valid non-empty slice of strings")
 		}
 	} else {
-		publicSubnets, err := ac.findPublicSubnets(vpcID, ac.filterByName("{infraID}*-public-{region}*"))
+		var err error
+
+		publicSubnets, err = ac.findPublicSubnets(vpcID, ac.filterByName("{infraID}*-public-{region}*"))
 		if err != nil {
 			return errors.Wrapf(err, "unable to find the public subnet")
 		}


### PR DESCRIPTION
Backport of #1026 on release-0.19.

#1026: Fix aws cloud prepare failure

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.