### PR TITLE
Restore for loop in aws cloud prepare for owned filters

### DIFF
--- a/pkg/aws/aws_cloud_test.go
+++ b/pkg/aws/aws_cloud_test.go
@@ -40,6 +40,7 @@ func testOpenPorts() {
 
 	JustBeforeEach(func() {
 		t.expectDescribeVpcs(t.vpcID)
+		t.expectDescribeVpcsSigs(t.vpcID)
 		t.expectDescribePublicSubnets(t.subnets...)
 
 		retError = t.cloud.OpenPorts([]api.PortSpec{
@@ -116,6 +117,7 @@ func testClosePorts() {
 
 	JustBeforeEach(func() {
 		t.expectDescribeVpcs(t.vpcID)
+		t.expectDescribeVpcsSigs(t.vpcID)
 		t.expectDescribePublicSubnets(t.subnets...)
 		t.expectDescribePublicSubnetsSigs(t.subnets...)
 

--- a/pkg/aws/aws_suite_test.go
+++ b/pkg/aws/aws_suite_test.go
@@ -111,8 +111,24 @@ func (f *fakeAWSClientBase) expectDescribeVpcs(vpcID string) {
 	}, {
 		Name:   ptr.To(clusterFilterTagName),
 		Values: []string{"owned"},
+	}}}).Matches))).Return(&ec2.DescribeVpcsOutput{Vpcs: vpcs}, nil).Maybe()
+}
+
+func (f *fakeAWSClientBase) expectDescribeVpcsSigs(vpcID string) {
+	var vpcs []types.Vpc
+	if vpcID != "" {
+		vpcs = []types.Vpc{
+			{
+				VpcId: ptr.To(vpcID),
+			},
+		}
+	}
+
+	f.awsClient.EXPECT().DescribeVpcs(mock.Anything, mock.MatchedBy(((&filtersMatcher{expectedFilters: []types.Filter{{
+		Name:   ptr.To("tag:Name"),
+		Values: []string{infraID + "-vpc"},
 	}, {
-		Name:   ptr.To(providerAWSTagPrefix + infraID),
+		Name:   ptr.To(clusterFilterTagNameSigs),
 		Values: []string{"owned"},
 	}}}).Matches))).Return(&ec2.DescribeVpcsOutput{Vpcs: vpcs}, nil).Maybe()
 }

--- a/pkg/aws/ocpgwdeployer_test.go
+++ b/pkg/aws/ocpgwdeployer_test.go
@@ -284,6 +284,7 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 		t.expectDescribeInstances(instanceImageID)
 		t.expectDescribeSecurityGroups(workerSGName, workerGroupID)
 		t.expectDescribePublicSubnets(t.subnets...)
+		t.expectDescribeVpcsSigs(t.vpcID)
 		t.expectDescribePublicSubnetsSigs(t.subnets...)
 
 		var err error

--- a/pkg/aws/vpcs.go
+++ b/pkg/aws/vpcs.go
@@ -42,14 +42,20 @@ func (ac *awsCloud) getVpcID() (string, error) {
 	ownedFilters := ac.filterByCurrentCluster()
 	vpcName := ac.withAWSInfo("{infraID}-vpc")
 
-	filters := []types.Filter{
-		ac.filterByName(vpcName),
-	}
-	filters = append(filters, ownedFilters...)
+	for i := range ownedFilters {
+		filters := []types.Filter{
+			ac.filterByName(vpcName),
+			ownedFilters[i],
+		}
 
-	result, err = ac.client.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{Filters: filters})
-	if err != nil {
-		return "", errors.Wrap(err, "error describing AWS VPCs")
+		result, err = ac.client.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{Filters: filters})
+		if err != nil {
+			return "", errors.Wrap(err, "error describing AWS VPCs")
+		}
+
+		if len(result.Vpcs) != 0 {
+			break
+		}
 	}
 
 	if len(result.Vpcs) == 0 {


### PR DESCRIPTION
While retrieving vpc the owned filters should be tried one after the other than together.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
