### PR TITLE
Automated backport of #1046: Restore for loop in aws cloud prepare for owned filters

### DIFF
--- a/pkg/aws/aws_cloud_test.go
+++ b/pkg/aws/aws_cloud_test.go
@@ -40,6 +40,7 @@ func testOpenPorts() {
 
 	JustBeforeEach(func() {
 		t.expectDescribeVpcs(t.vpcID)
+		t.expectDescribeVpcsSigs(t.vpcID)
 		t.expectDescribePublicSubnets(t.subnets...)
 
 		retError = t.cloud.OpenPorts([]api.PortSpec{
@@ -116,6 +117,7 @@ func testClosePorts() {
 
 	JustBeforeEach(func() {
 		t.expectDescribeVpcs(t.vpcID)
+		t.expectDescribeVpcsSigs(t.vpcID)
 		t.expectDescribePublicSubnets(t.subnets...)
 		t.expectDescribePublicSubnetsSigs(t.subnets...)
 

--- a/pkg/aws/aws_suite_test.go
+++ b/pkg/aws/aws_suite_test.go
@@ -115,8 +115,24 @@ func (f *fakeAWSClientBase) expectDescribeVpcs(vpcID string) {
 	}, types.Filter{
 		Name:   awssdk.String(clusterFilterTagName),
 		Values: []string{"owned"},
+	})).Return(&ec2.DescribeVpcsOutput{Vpcs: vpcs}, nil).AnyTimes()
+}
+
+func (f *fakeAWSClientBase) expectDescribeVpcsSigs(vpcID string) {
+	var vpcs []types.Vpc
+	if vpcID != "" {
+		vpcs = []types.Vpc{
+			{
+				VpcId: ptr.To(vpcID),
+			},
+		}
+	}
+
+	f.awsClient.EXPECT().DescribeVpcs(gomock.Any(), eqFilters(types.Filter{
+		Name:   ptr.To("tag:Name"),
+		Values: []string{infraID + "-vpc"},
 	}, types.Filter{
-		Name:   ptr.To(providerAWSTagPrefix + infraID),
+		Name:   ptr.To(clusterFilterTagNameSigs),
 		Values: []string{"owned"},
 	})).Return(&ec2.DescribeVpcsOutput{Vpcs: vpcs}, nil).AnyTimes()
 }

--- a/pkg/aws/ocpgwdeployer_test.go
+++ b/pkg/aws/ocpgwdeployer_test.go
@@ -284,6 +284,7 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 		t.expectDescribeInstances(instanceImageID)
 		t.expectDescribeSecurityGroups(workerSGName, workerGroupID)
 		t.expectDescribePublicSubnets(t.subnets...)
+		t.expectDescribeVpcsSigs(t.vpcID)
 		t.expectDescribePublicSubnetsSigs(t.subnets...)
 
 		var err error

--- a/pkg/aws/vpcs.go
+++ b/pkg/aws/vpcs.go
@@ -42,14 +42,20 @@ func (ac *awsCloud) getVpcID() (string, error) {
 	ownedFilters := ac.filterByCurrentCluster()
 	vpcName := ac.withAWSInfo("{infraID}-vpc")
 
-	filters := []types.Filter{
-		ac.filterByName(vpcName),
-	}
-	filters = append(filters, ownedFilters...)
+	for i := range ownedFilters {
+		filters := []types.Filter{
+			ac.filterByName(vpcName),
+			ownedFilters[i],
+		}
 
-	result, err = ac.client.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{Filters: filters})
-	if err != nil {
-		return "", errors.Wrap(err, "error describing AWS VPCs")
+		result, err = ac.client.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{Filters: filters})
+		if err != nil {
+			return "", errors.Wrap(err, "error describing AWS VPCs")
+		}
+
+		if len(result.Vpcs) != 0 {
+			break
+		}
 	}
 
 	if len(result.Vpcs) == 0 {


### PR DESCRIPTION
Backport of #1046 on release-0.17.

#1046: Restore for loop in aws cloud prepare for owned filters

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.