### PR TITLE
Add kubernetes tag in the security group

### DIFF
--- a/pkg/aws/aws_suite_test.go
+++ b/pkg/aws/aws_suite_test.go
@@ -222,6 +222,10 @@ func (f *fakeAWSClientBase) expectCreateSecurityGroup(name, retGroupID string) {
 						Key:   ptr.To("Name"),
 						Value: ptr.To(name),
 					},
+					{
+						Key:   ptr.To("kubernetes.io/cluster/" + infraID),
+						Value: ptr.To("owned"),
+					},
 				},
 			},
 		},

--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -195,6 +195,7 @@ func (ac *awsCloud) createGatewaySG(vpcID string, ports []api.PortSpec) (string,
 					ResourceType: types.ResourceTypeSecurityGroup,
 					Tags: []types.Tag{
 						ec2Tag("Name", groupName),
+						ec2Tag(ac.withAWSInfo("kubernetes.io/cluster/{infraID}"), "owned"),
 					},
 				},
 			},


### PR DESCRIPTION
Newer Kubernetes versions restrict AWS instances to maximum 1 untagged security group for LoadBalancer creation. After Submariner deployment, gateway nodes have 2 untagged security groups (Kubernetes
default + Submariner gateway), violating this limit.

Fix: Tag the Submariner gateway security group with kubernetes.io/cluster/<infraID>=owned to comply with the restriction.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced AWS security group tagging to include a Kubernetes cluster identifier tag ("kubernetes.io/cluster/...":"owned") alongside the existing Name tag for improved resource identification and tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->