### PR TITLE
Drop obsolete nolints with golangci-lint 2.7.1

### DIFF
--- a/pkg/azure/cloud_info.go
+++ b/pkg/azure/cloud_info.go
@@ -94,7 +94,7 @@ func (c *CloudInfo) openInternalPorts(infraID string, ports []api.PortSpec, nsgC
 	}
 
 	for i, port := range ports {
-		p := int32(i) //nolint:gosec // Ignore integer overflow conversion
+		p := int32(i)
 
 		nwSecurityGroup.Properties.SecurityRules = append(nwSecurityGroup.Properties.SecurityRules,
 			c.createSecurityRule(internalSecurityRulePrefix, armnetwork.SecurityRuleProtocol(port.Protocol), port.Port,
@@ -190,7 +190,7 @@ func (c *CloudInfo) createGWSecurityGroup(groupName string, ports []api.PortSpec
 	securityRules := []*armnetwork.SecurityRule{}
 
 	for i, port := range ports {
-		p := int32(i) //nolint:gosec // Ignore integer overflow conversion
+		p := int32(i)
 		securityRules = append(securityRules,
 			c.createSecurityRule(externalSecurityRulePrefix, armnetwork.SecurityRuleProtocol(port.Protocol), port.Port,
 				baseExternalInternal+p, armnetwork.SecurityRuleDirectionInbound),


### PR DESCRIPTION
Depends on https://github.com/submariner-io/shipyard/pull/2224