### PR TITLE
Add custom network support in OSP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ Makefile.dapper
 Makefile.shipyard
 /Dockerfile.*
 .idea
-*.coverprofile
+*coverprofile*
 junit.xml
 

--- a/pkg/rhos/gw-machineset.go
+++ b/pkg/rhos/gw-machineset.go
@@ -62,13 +62,16 @@ spec:
           networks:
           - filter: {}
             subnets:
+            {{ if len .SubnetNames }}
             {{- range .SubnetNames}}
             - filter:
-                name: {{.}}
-                {{- if not $.IsCustomSubnet}}
-                tags: openshiftClusterID={{$.InfraID}}
-                {{- end}}
+                 name: {{.}}
             {{- end}}
+            {{ else }}
+            - filter:
+                 name: {{.InfraID}}-nodes
+                 tags: openshiftClusterID={{.InfraID}}
+            {{ end }}
           securityGroups:
           - name: {{.InfraID}}-worker
           {{- if .UseSubmarinerInternalSG }}

--- a/pkg/rhos/gw-machineset.go
+++ b/pkg/rhos/gw-machineset.go
@@ -62,9 +62,13 @@ spec:
           networks:
           - filter: {}
             subnets:
+            {{- range .SubnetNames}}
             - filter:
-                name: {{.InfraID}}-nodes
-                tags: openshiftClusterID={{.InfraID}}
+                name: {{.}}
+                {{- if not $.IsCustomSubnet}}
+                tags: openshiftClusterID={{$.InfraID}}
+                {{- end}}
+            {{- end}}
           securityGroups:
           - name: {{.InfraID}}-worker
           {{- if .UseSubmarinerInternalSG }}

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -70,7 +70,6 @@ type machineSetConfig struct {
 	SubmarinerGWNodeTag     string
 	CloudName               string
 	UseSubmarinerInternalSG bool
-	IsCustomSubnet          bool
 }
 
 func (d *ocpGatewayDeployer) loadGatewayYAML(uuidGW, image string, useInternalSG bool) ([]byte, error) {
@@ -92,7 +91,6 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(uuidGW, image string, useInternalSG
 		SubnetNames:             d.SubnetNames,
 		SubmarinerGWNodeTag:     SubmarinerGatewayNodeTag,
 		UseSubmarinerInternalSG: useInternalSG,
-		IsCustomSubnet:          len(d.SubnetNames) > 0 && d.SubnetNames[0] != d.InfraID+"-nodes",
 	}
 
 	err = tpl.Execute(&buf, tplVars)

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -46,6 +46,8 @@ type ocpGatewayDeployer struct {
 }
 
 // NewOcpGatewayDeployer returns a GatewayDeployer capable of deploying gateways using OCP.
+//
+//nolint:gocritic // Ignore 'hugeParam' - pass by value for CloudInfo is intentional.
 func NewOcpGatewayDeployer(info CloudInfo, msDeployer ocp.MachineSetDeployer, projectID, instanceType, image, cloudName string,
 ) api.GatewayDeployer {
 	return &ocpGatewayDeployer{
@@ -65,9 +67,11 @@ type machineSetConfig struct {
 	InstanceType            string
 	Region                  string
 	Image                   string
+	SubnetNames             []string
 	SubmarinerGWNodeTag     string
 	CloudName               string
 	UseSubmarinerInternalSG bool
+	IsCustomSubnet          bool
 }
 
 func (d *ocpGatewayDeployer) loadGatewayYAML(uuidGW, image string, useInternalSG bool) ([]byte, error) {
@@ -86,8 +90,10 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(uuidGW, image string, useInternalSG
 		Region:                  d.Region,
 		CloudName:               d.cloudName,
 		Image:                   image,
+		SubnetNames:             d.SubnetNames,
 		SubmarinerGWNodeTag:     submarinerGatewayNodeTag,
 		UseSubmarinerInternalSG: useInternalSG,
+		IsCustomSubnet:          len(d.SubnetNames) > 0 && d.SubnetNames[0] != d.InfraID+"-nodes",
 	}
 
 	err = tpl.Execute(&buf, tplVars)

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -26,7 +26,6 @@ import (
 	"text/template"
 
 	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/cloud-prepare/pkg/api"
@@ -91,7 +90,7 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(uuidGW, image string, useInternalSG
 		CloudName:               d.cloudName,
 		Image:                   image,
 		SubnetNames:             d.SubnetNames,
-		SubmarinerGWNodeTag:     submarinerGatewayNodeTag,
+		SubmarinerGWNodeTag:     SubmarinerGatewayNodeTag,
 		UseSubmarinerInternalSG: useInternalSG,
 		IsCustomSubnet:          len(d.SubnetNames) > 0 && d.SubnetNames[0] != d.InfraID+"-nodes",
 	}
@@ -142,17 +141,17 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 	status.Start("Configuring the required firewall rules for inter-cluster traffic")
 	defer status.End()
 
-	computeClient, err := openstack.NewComputeV2(d.Client, gophercloud.EndpointOpts{Region: d.Region})
+	computeClient, err := NewComputeV2(d.Client, gophercloud.EndpointOpts{Region: d.Region})
 	if err != nil {
 		return status.Error(err, "error creating the compute client")
 	}
 
-	networkClient, err := openstack.NewNetworkV2(d.Client, gophercloud.EndpointOpts{Region: d.Region})
+	networkClient, err := NewNetworkV2(d.Client, gophercloud.EndpointOpts{Region: d.Region})
 	if err != nil {
 		return status.Error(err, "error creating the network client")
 	}
 
-	groupName := d.InfraID + gwSecurityGroupSuffix
+	groupName := d.InfraID + GwSecurityGroupSuffix
 	if err := d.createGWSecurityGroup(input.PublicPorts, groupName, computeClient, networkClient); err != nil {
 		return status.Error(err, "creating gateway security group failed")
 	}
@@ -167,11 +166,8 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 		return status.Error(err, "listing the existing gateway nodes failed")
 	}
 
-	gwNodeItems := gwNodes.Items
-
-	gwNodesList := gwNodes.Items
-	for i := range gwNodesList {
-		err := d.openGatewayPort(groupName, gwNodesList[i].Name, computeClient)
+	for i := range gwNodes.Items {
+		err := addServerSecurityGroups(gwNodes.Items[i].Name, groupName, computeClient)
 		if err != nil {
 			return status.Error(err, "failed to open the gateway port in the existing g/w node")
 		}
@@ -180,7 +176,7 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 	status.Success("Opened external ports %q in security group %q on RHOS for existing g/w nodes",
 		formatPorts(input.PublicPorts), groupName)
 
-	taggedExistingNodes := ocp.RemoveDuplicates(machineSets, gwNodeItems)
+	taggedExistingNodes := ocp.RemoveDuplicates(machineSets, gwNodes.Items)
 	gatewayNodesToDeploy := input.Gateways - len(machineSets) - len(taggedExistingNodes)
 
 	if gatewayNodesToDeploy == 0 {
@@ -203,7 +199,7 @@ func (d *ocpGatewayDeployer) deployGWNode(gatewayCount int,
 	if numGatewayNodes < gatewayCount {
 		gatewayNodesToDeploy := gatewayCount - numGatewayNodes
 
-		groupName := d.InfraID + internalSecurityGroupSuffix
+		groupName := d.InfraID + InternalSecurityGroupSuffix
 
 		isFound, errSG := checkIfSecurityGroupPresent(groupName, computeClient)
 		if errSG != nil {
@@ -236,12 +232,12 @@ func (d *ocpGatewayDeployer) deployDedicatedGWNode(gatewayNodesToDeploy int, use
 }
 
 func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
-	computeClient, err := openstack.NewComputeV2(d.Client, gophercloud.EndpointOpts{Region: d.Region})
+	computeClient, err := NewComputeV2(d.Client, gophercloud.EndpointOpts{Region: d.Region})
 	if err != nil {
 		return status.Error(err, "error creating the compute client for the region: %q", d.Region)
 	}
 
-	groupName := d.InfraID + gwSecurityGroupSuffix
+	groupName := d.InfraID + GwSecurityGroupSuffix
 
 	machineSetList, err := d.msDeployer.List()
 	if err != nil {
@@ -253,7 +249,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 		status.Start("Removing the Submariner gateway security group rules from node %q",
 			machineSetList[i].GetName())
 
-		err = d.removeFirewallRulesFromGW(groupName, machineSetList[i].GetName(), computeClient)
+		err = removeServerSecurityGroups(machineSetList[i].GetName(), groupName, computeClient)
 		if err != nil {
 			return status.Error(err, "error deleting the security group rules")
 		}
@@ -282,7 +278,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 	for i := range gwNodes {
 		status.Start("Deleting the Submariner gateway security group rules from node %q", gwNodes[i].Name)
 
-		err = d.removeFirewallRulesFromGW(groupName, gwNodes[i].Name, computeClient)
+		err = removeServerSecurityGroups(gwNodes[i].Name, groupName, computeClient)
 		if err != nil {
 			return status.Error(err, "error deleting the security group rules")
 		}
@@ -294,7 +290,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 
 		err = d.K8sClient.RemoveGWLabelFromWorkerNode(&gwNodes[i])
 		if err != nil {
-			return status.Error(err, "failed to cleanup gateway node %q"+gwNodes[i].Name)
+			return status.Error(err, "failed to cleanup gateway node %q", gwNodes[i].Name)
 		}
 	}
 

--- a/pkg/rhos/ocpgwdeployer_test.go
+++ b/pkg/rhos/ocpgwdeployer_test.go
@@ -68,6 +68,31 @@ func testDeploy() {
 		t.assertRuleCreated(rhos.GwSecurityGroupSuffix, t.gwDeployInput.PublicPorts[1])
 	})
 
+	When("custom subnets are provided", func() {
+		const (
+			subnetName1 = "subnet1"
+			subnetName2 = "subnet2"
+		)
+
+		BeforeEach(func() {
+			t.subnetNames = []string{subnetName1, subnetName2}
+		})
+
+		It("should deploy a gateway node machine with the subnets applied", func() {
+			Expect(t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout())).To(Succeed())
+
+			t.assertMachineSet(false, SubnetParam{
+				Filter: SubnetFilter{
+					Name: subnetName1,
+				},
+			}, SubnetParam{
+				Filter: SubnetFilter{
+					Name: subnetName2,
+				},
+			})
+		})
+	})
+
 	When("the internal security group exists", func() {
 		BeforeEach(func() {
 			t.existingSecurityGroups = []secgroups.SecurityGroup{
@@ -185,6 +210,7 @@ type gatewayDeployerTestDriver struct {
 	machineSetsDeployed []*unstructured.Unstructured
 	existingMachineSets []unstructured.Unstructured
 	gwDeployInput       api.GatewayDeployInput
+	subnetNames         []string
 }
 
 func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
@@ -195,6 +221,7 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 		t.kubeClient = k8sfake.NewClientset()
 		t.machineSetsDeployed = nil
 		t.existingMachineSets = nil
+		t.subnetNames = nil
 
 		t.gwDeployInput = api.GatewayDeployInput{
 			Gateways: 1,
@@ -225,10 +252,11 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 		}).Maybe()
 
 		t.gwDeployer = rhos.NewOcpGatewayDeployer(rhos.CloudInfo{
-			Client:    &gophercloud.ProviderClient{},
-			InfraID:   testInfraID,
-			Region:    testRegion,
-			K8sClient: k8s.NewInterface(t.kubeClient),
+			Client:      &gophercloud.ProviderClient{},
+			InfraID:     testInfraID,
+			Region:      testRegion,
+			K8sClient:   k8s.NewInterface(t.kubeClient),
+			SubnetNames: t.subnetNames,
 		}, t.msDeployer, testProjectID, testInstanceType, "", testCloudName)
 	})
 

--- a/pkg/rhos/ocpgwdeployer_test.go
+++ b/pkg/rhos/ocpgwdeployer_test.go
@@ -1,0 +1,301 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rhos_test
+
+import (
+	"context"
+	"slices"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	"github.com/submariner-io/cloud-prepare/pkg/k8s"
+	ocpfake "github.com/submariner-io/cloud-prepare/pkg/ocp/fake"
+	"github.com/submariner-io/cloud-prepare/pkg/rhos"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+var _ = Describe("OCP Gateway Deployer", func() {
+	Context("Deploy", testDeploy)
+	Context("Cleanup", testCleanup)
+})
+
+func testDeploy() {
+	t := newGatewayDeployerTestDriver()
+
+	BeforeEach(func() {
+		t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, testInfraID).Return(testImage, nil).Maybe()
+	})
+
+	It("should deploy a gateway node machine set and security group rules", func() {
+		Expect(t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout())).To(Succeed())
+
+		t.assertMachineSet(false, SubnetParam{
+			Filter: SubnetFilter{
+				Name: testInfraID + "-nodes",
+				Tags: "openshiftClusterID=" + testInfraID,
+			},
+		})
+
+		Expect(t.securityGroupsCreated).To(ContainElement(ContainSubstring(rhos.GwSecurityGroupSuffix)))
+
+		t.assertRuleCreated(rhos.GwSecurityGroupSuffix, t.gwDeployInput.PublicPorts[0])
+		t.assertRuleCreated(rhos.GwSecurityGroupSuffix, t.gwDeployInput.PublicPorts[1])
+	})
+
+	When("the internal security group exists", func() {
+		BeforeEach(func() {
+			t.existingSecurityGroups = []secgroups.SecurityGroup{
+				{
+					Name: internalSecurityGroup,
+				},
+			}
+		})
+
+		It("should deploy a gateway node machine set with the internal security group", func() {
+			Expect(t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout())).To(Succeed())
+			t.assertMachineSet(true)
+		})
+	})
+
+	When("the gateway security group already exists", func() {
+		BeforeEach(func() {
+			t.existingSecurityGroups = []secgroups.SecurityGroup{
+				{
+					Name: gwSecurityGroup,
+				},
+			}
+		})
+
+		It("should not try to recreate it", func() {
+			Expect(t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout())).To(Succeed())
+			Expect(t.securityGroupsCreated).To(BeEmpty())
+		})
+	})
+
+	When("a node is already labeled as a gateway", func() {
+		BeforeEach(func() {
+			for _, name := range []string{nodeName1, nodeName2} {
+				t.createGatewayNode(name)
+			}
+		})
+
+		It("should open the gateway port and not deploy a machine set", func() {
+			Expect(t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout())).To(Succeed())
+			t.assertServerSecGroup(gwSecurityGroup)
+		})
+
+		t.testErrors(func() error { return t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout()) },
+			extractServersErrEntry())
+	})
+
+	t.testErrors(func() error { return t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout()) },
+		newComputeV2ErrEntry(),
+		newNetworkV2ErrEntry(),
+		createSecurityGroupErrEntry(),
+		extractSecurityGroupsErrEntry())
+}
+
+func testCleanup() {
+	t := newGatewayDeployerTestDriver()
+
+	BeforeEach(func() {
+		t.existingMachineSets = []unstructured.Unstructured{
+			{
+				Object: map[string]any{
+					"apiVersion": "machine.openshift.io/v1beta1",
+					"kind":       "MachineSet",
+					"metadata": map[string]any{
+						"name": nodeName1,
+					},
+				},
+			},
+			{
+				Object: map[string]any{
+					"apiVersion": "machine.openshift.io/v1beta1",
+					"kind":       "MachineSet",
+					"metadata": map[string]any{
+						"name": nodeName2,
+					},
+				},
+			},
+		}
+
+		t.existingSecurityGroups = []secgroups.SecurityGroup{
+			{
+				Name: gwSecurityGroup,
+				ID:   gwSecurityGroup,
+			},
+		}
+
+		t.servers[nodeName3] = &servers.Server{ID: serverID3}
+
+		t.createGatewayNode(nodeName3)
+	})
+
+	It("should delete the gateway machine sets and security groups", func() {
+		Expect(t.gwDeployer.Cleanup(reporter.Stdout())).To(Succeed())
+		Expect(t.existingMachineSets).To(BeEmpty())
+		Expect(t.existingSecurityGroups).To(BeEmpty())
+		t.assertNoServerSecGroup(gwSecurityGroup)
+
+		node, err := t.kubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName3, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(node.Labels).NotTo(HaveKey(k8s.SubmarinerGatewayLabel))
+	})
+
+	t.testErrors(func() error { return t.gwDeployer.Cleanup(reporter.Stdout()) },
+		newComputeV2ErrEntry(),
+		deleteSecurityGroupErrEntry(),
+		extractSecurityGroupsErrEntry(),
+		extractServersErrEntry(),
+		removeServerErrEntry())
+}
+
+type gatewayDeployerTestDriver struct {
+	*testDriver
+	msDeployer          *ocpfake.MockMachineSetDeployer
+	gwDeployer          api.GatewayDeployer
+	kubeClient          *k8sfake.Clientset
+	machineSetsDeployed []*unstructured.Unstructured
+	existingMachineSets []unstructured.Unstructured
+	gwDeployInput       api.GatewayDeployInput
+}
+
+func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
+	t := &gatewayDeployerTestDriver{testDriver: newTestDriver()}
+
+	BeforeEach(func() {
+		t.msDeployer = ocpfake.NewMockMachineSetDeployer(GinkgoT())
+		t.kubeClient = k8sfake.NewClientset()
+		t.machineSetsDeployed = nil
+		t.existingMachineSets = nil
+
+		t.gwDeployInput = api.GatewayDeployInput{
+			Gateways: 1,
+			PublicPorts: []api.PortSpec{
+				{
+					Port:     100,
+					Protocol: "TCP",
+				},
+				{
+					Port:     200,
+					Protocol: "UDP",
+				},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		t.msDeployer.EXPECT().Deploy(mock.Anything).RunAndReturn(t.machineSetFn()).Maybe()
+		t.msDeployer.EXPECT().List().Return(slices.Clone(t.existingMachineSets), nil).Maybe()
+
+		t.msDeployer.EXPECT().DeleteByName(mock.Anything, mock.Anything).RunAndReturn(func(msName, _ string) error {
+			t.existingMachineSets = slices.DeleteFunc(t.existingMachineSets, func(u unstructured.Unstructured) bool {
+				name, _, _ := unstructured.NestedString(u.Object, "metadata", "name")
+				return name == msName
+			})
+
+			return nil
+		}).Maybe()
+
+		t.gwDeployer = rhos.NewOcpGatewayDeployer(rhos.CloudInfo{
+			Client:    &gophercloud.ProviderClient{},
+			InfraID:   testInfraID,
+			Region:    testRegion,
+			K8sClient: k8s.NewInterface(t.kubeClient),
+		}, t.msDeployer, testProjectID, testInstanceType, "", testCloudName)
+	})
+
+	return t
+}
+
+func (t *gatewayDeployerTestDriver) machineSetFn() func(ms *unstructured.Unstructured) error {
+	return func(ms *unstructured.Unstructured) error {
+		t.machineSetsDeployed = append(t.machineSetsDeployed, ms)
+		return nil
+	}
+}
+
+func (t *gatewayDeployerTestDriver) assertMachineSet(useInternalSG bool, expSubnets ...SubnetParam) {
+	Expect(t.machineSetsDeployed).To(HaveLen(1))
+
+	ms := t.machineSetsDeployed[0]
+	Expect(ms.GetLabels()).To(HaveKeyWithValue("machine.openshift.io/cluster-api-cluster", testInfraID))
+	values, found, err := unstructured.NestedMap(ms.Object, "spec", "template", "spec", "providerSpec", "value")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue())
+
+	Expect(values).To(HaveKeyWithValue("cloudName", testCloudName))
+	Expect(values).To(HaveKeyWithValue("flavor", testInstanceType))
+	Expect(values).To(HaveKeyWithValue("image", testImage))
+
+	tags, found, err := unstructured.NestedSlice(values, "tags")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue())
+	Expect(tags).To(ContainElement(rhos.SubmarinerGatewayNodeTag))
+
+	networks, found, err := unstructured.NestedSlice(values, "networks")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue())
+	Expect(networks).To(HaveLen(1))
+
+	if len(expSubnets) > 0 {
+		subnetObjs, found, err := unstructured.NestedSlice(networks[0].(map[string]any), "subnets")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+
+		actualSubnets := make([]SubnetParam, 0, len(subnetObjs))
+
+		for _, s := range subnetObjs {
+			var subnet SubnetParam
+			Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(s.(map[string]any), &subnet)).To(Succeed())
+
+			actualSubnets = append(actualSubnets, subnet)
+		}
+
+		Expect(actualSubnets).To(ConsistOf(expSubnets))
+	}
+
+	secGroups, found, err := unstructured.NestedSlice(values, "securityGroups")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue())
+	Expect(slices.ContainsFunc(secGroups, func(i any) bool {
+		return i.(map[string]any)["name"] == testInfraID+rhos.InternalSecurityGroupSuffix
+	})).To(Equal(useInternalSG))
+}
+
+func (t *gatewayDeployerTestDriver) createGatewayNode(name string) {
+	_, err := t.kubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{k8s.SubmarinerGatewayLabel: "true"},
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/pkg/rhos/rhos.go
+++ b/pkg/rhos/rhos.go
@@ -37,10 +37,14 @@ type rhosCloud struct {
 }
 
 // NewCloud creates a new api.Cloud instance which can prepare RHOS for Submariner to be deployed on it.
-func NewCloud(info CloudInfo) api.Cloud {
-	return &rhosCloud{
-		CloudInfo: info,
+func NewCloud(info CloudInfo) api.Cloud { //nolint:gocritic // Ignore 'hugeParam' - pass by value for CloudInfo is intentional.
+	rhosCloud := &rhosCloud{CloudInfo: info}
+
+	if len(rhosCloud.SubnetNames) == 0 {
+		rhosCloud.SubnetNames = []string{info.InfraID + "-nodes"}
 	}
+
+	return rhosCloud
 }
 
 func (rc *rhosCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {

--- a/pkg/rhos/rhos.go
+++ b/pkg/rhos/rhos.go
@@ -43,13 +43,7 @@ type rhosCloud struct {
 
 // NewCloud creates a new api.Cloud instance which can prepare RHOS for Submariner to be deployed on it.
 func NewCloud(info CloudInfo) api.Cloud { //nolint:gocritic // Ignore 'hugeParam' - pass by value for CloudInfo is intentional.
-	rhosCloud := &rhosCloud{CloudInfo: info}
-
-	if len(rhosCloud.SubnetNames) == 0 {
-		rhosCloud.SubnetNames = []string{info.InfraID + "-nodes"}
-	}
-
-	return rhosCloud
+	return &rhosCloud{CloudInfo: info}
 }
 
 func (rc *rhosCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {

--- a/pkg/rhos/rhos.go
+++ b/pkg/rhos/rhos.go
@@ -26,10 +26,15 @@ import (
 )
 
 const (
-	gwSecurityGroupSuffix       = "-submariner-gw-sg"
-	internalSecurityGroupSuffix = "-submariner-internal-sg"
-	submarinerGatewayNodeTag    = "submariner-io-gateway-node"
+	GwSecurityGroupSuffix       = "-submariner-gw-sg"
+	InternalSecurityGroupSuffix = "-submariner-internal-sg"
+	SubmarinerGatewayNodeTag    = "submariner-io-gateway-node"
 	allNetworkCIDR              = "0.0.0.0/0"
+)
+
+var (
+	NewComputeV2 = openstack.NewComputeV2
+	NewNetworkV2 = openstack.NewNetworkV2
 )
 
 type rhosCloud struct {
@@ -51,12 +56,12 @@ func (rc *rhosCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) 
 	status.Start("Opening internal ports for intra-cluster communications on RHOS")
 	defer status.End()
 
-	computeClient, err := openstack.NewComputeV2(rc.Client, gophercloud.EndpointOpts{Region: rc.Region})
+	computeClient, err := NewComputeV2(rc.Client, gophercloud.EndpointOpts{Region: rc.Region})
 	if err != nil {
 		return status.Error(err, "error creating the compute client")
 	}
 
-	networkClient, err := openstack.NewNetworkV2(rc.Client, gophercloud.EndpointOpts{Region: rc.Region})
+	networkClient, err := NewNetworkV2(rc.Client, gophercloud.EndpointOpts{Region: rc.Region})
 	if err != nil {
 		return status.Error(err, "error creating the network client")
 	}
@@ -73,7 +78,7 @@ func (rc *rhosCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) 
 func (rc *rhosCloud) ClosePorts(status reporter.Interface) error {
 	status.Start("Revoking intra-cluster communication permissions")
 
-	computeClient, err := openstack.NewComputeV2(rc.Client, gophercloud.EndpointOpts{Region: rc.Region})
+	computeClient, err := NewComputeV2(rc.Client, gophercloud.EndpointOpts{Region: rc.Region})
 	if err != nil {
 		return status.Error(err, "creating compute client failed for region %q", rc.Region)
 	}
@@ -82,7 +87,7 @@ func (rc *rhosCloud) ClosePorts(status reporter.Interface) error {
 		return status.Error(err, "unable to remove firewall rules")
 	}
 
-	if err := rc.deleteSG(rc.InfraID+internalSecurityGroupSuffix, computeClient); err != nil {
+	if err := rc.deleteSG(rc.InfraID+InternalSecurityGroupSuffix, computeClient); err != nil {
 		return err
 	}
 

--- a/pkg/rhos/rhos_suite_test.go
+++ b/pkg/rhos/rhos_suite_test.go
@@ -1,0 +1,367 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rhos_test
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/pagination"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	"github.com/submariner-io/cloud-prepare/pkg/rhos"
+)
+
+const (
+	testInfraID           = "test-infra"
+	testRegion            = "test-region"
+	testProjectID         = "test-project"
+	testInstanceType      = "m1.medium"
+	testImage             = "rhcos-test-image"
+	testCloudName         = "openstack"
+	pagerNameKey          = "pagerNameKey"
+	secGroupPager         = "secGroupPager"
+	serverID1             = "server1"
+	serverID2             = "server2"
+	serverID3             = "server3"
+	nodeName1             = "node1"
+	nodeName2             = "node2"
+	nodeName3             = "node3"
+	gwSecurityGroup       = testInfraID + rhos.GwSecurityGroupSuffix
+	internalSecurityGroup = testInfraID + rhos.InternalSecurityGroupSuffix
+)
+
+func TestRHOS(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RHOS Suite")
+}
+
+type testDriver struct {
+	securityGroupsCreated  []string
+	rulesCreated           []rules.SecGroupRule
+	existingSecurityGroups []secgroups.SecurityGroup
+	servers                map[string]*servers.Server
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{}
+
+	BeforeEach(func() {
+		t.securityGroupsCreated = nil
+		t.rulesCreated = nil
+		t.existingSecurityGroups = nil
+
+		t.servers = map[string]*servers.Server{
+			nodeName1: {
+				ID: serverID1,
+			},
+			nodeName2: {
+				ID: serverID2,
+				SecurityGroups: []map[string]any{
+					{"name": gwSecurityGroup},
+				},
+			},
+		}
+
+		rhos.NewComputeV2 = func(_ *gophercloud.ProviderClient, _ gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+			return &gophercloud.ServiceClient{}, nil
+		}
+
+		rhos.NewNetworkV2 = func(_ *gophercloud.ProviderClient, _ gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+			return &gophercloud.ServiceClient{}, nil
+		}
+
+		rhos.ListSecurityGroups = func(c *gophercloud.ServiceClient) pagination.Pager {
+			return pagination.Pager{
+				Headers: map[string]string{pagerNameKey: secGroupPager},
+			}
+		}
+
+		rhos.ExtractSecurityGroups = func(page pagination.Page) ([]secgroups.SecurityGroup, error) {
+			sgPage, ok := page.(*SecGroupPage)
+			Expect(ok).To(BeTrue())
+
+			return sgPage.secGroups, nil
+		}
+
+		rhos.CreateSecurityGroup = func(_ *gophercloud.ServiceClient, o secgroups.CreateOptsBuilder) (*secgroups.SecurityGroup, error) {
+			name := o.(secgroups.CreateOpts).Name
+			t.securityGroupsCreated = append(t.securityGroupsCreated, name)
+
+			return &secgroups.SecurityGroup{Name: name, ID: name}, nil
+		}
+
+		rhos.DeleteSecurityGroup = func(_ *gophercloud.ServiceClient, id string) secgroups.DeleteResult {
+			t.existingSecurityGroups = slices.DeleteFunc(t.existingSecurityGroups, func(g secgroups.SecurityGroup) bool {
+				return g.ID == id
+			})
+
+			return secgroups.DeleteResult{}
+		}
+
+		rhos.ListServers = func(_ *gophercloud.ServiceClient, o servers.ListOptsBuilder) pagination.Pager {
+			return pagination.Pager{
+				Headers: map[string]string{pagerNameKey: o.(servers.ListOpts).Name},
+			}
+		}
+
+		rhos.ExtractServers = func(page pagination.Page) ([]servers.Server, error) {
+			serverPage, ok := page.(*ServerPage)
+			Expect(ok).To(BeTrue())
+
+			return serverPage.servers, nil
+		}
+
+		rhos.AddServer = func(_ *gophercloud.ServiceClient, serverID, groupName string) error {
+			server := t.findServer(serverID)
+			if server != nil && !slices.ContainsFunc(server.SecurityGroups, func(m map[string]any) bool {
+				return m["name"] == groupName
+			}) {
+				server.SecurityGroups = append(server.SecurityGroups, map[string]any{"name": groupName})
+			}
+
+			return nil
+		}
+
+		rhos.RemoveServer = func(_ *gophercloud.ServiceClient, serverID, groupName string) error {
+			secGroupFn := func(m map[string]any) bool {
+				return m["name"] == groupName
+			}
+
+			server := t.findServer(serverID)
+			if server != nil && slices.ContainsFunc(server.SecurityGroups, secGroupFn) {
+				server.SecurityGroups = slices.DeleteFunc(server.SecurityGroups, secGroupFn)
+				return nil
+			}
+
+			return gophercloud.ErrDefault404{}
+		}
+
+		rhos.EachPage = func(pager pagination.Pager, handler func(pagination.Page) (bool, error)) error {
+			var page pagination.Page
+			if pager.Headers[pagerNameKey] == secGroupPager {
+				page = &SecGroupPage{secGroups: t.existingSecurityGroups}
+			} else if pager.Headers[pagerNameKey] == testInfraID {
+				// Return all servers when listing by infraID
+				allServers := make([]servers.Server, 0, len(t.servers))
+				for _, server := range t.servers {
+					allServers = append(allServers, *server)
+				}
+
+				page = &ServerPage{servers: allServers}
+			} else {
+				server, ok := t.servers[pager.Headers[pagerNameKey]]
+				if ok {
+					page = &ServerPage{servers: []servers.Server{*server}}
+				}
+			}
+
+			Expect(page).NotTo(BeNil(), "No Pager for "+pager.Headers[pagerNameKey])
+
+			ok, err := handler(page)
+			if err != nil {
+				return err
+			}
+
+			Expect(ok).To(BeTrue())
+
+			return nil
+		}
+
+		rhos.CreateRule = func(_ *gophercloud.ServiceClient, o rules.CreateOptsBuilder) (*rules.SecGroupRule, error) {
+			opts := o.(rules.CreateOpts)
+
+			rule := &rules.SecGroupRule{
+				PortRangeMin:   opts.PortRangeMin,
+				PortRangeMax:   opts.PortRangeMax,
+				Protocol:       string(opts.Protocol),
+				RemoteGroupID:  opts.RemoteGroupID,
+				RemoteIPPrefix: opts.RemoteIPPrefix,
+				SecGroupID:     opts.SecGroupID,
+			}
+			t.rulesCreated = append(t.rulesCreated, *rule)
+
+			return rule, nil
+		}
+	})
+
+	return t
+}
+
+func (t *testDriver) findServer(serverID string) *servers.Server {
+	for _, server := range t.servers {
+		if server.ID == serverID {
+			return server
+		}
+	}
+
+	return nil
+}
+
+func (t *testDriver) assertRuleCreated(group string, port api.PortSpec) {
+	Expect(slices.ContainsFunc(t.rulesCreated, func(r rules.SecGroupRule) bool {
+		//nolint:gosec // Ignore integer overflow conversion
+		return strings.Contains(r.SecGroupID, group) && uint16(r.PortRangeMin) == port.Port && r.Protocol == port.Protocol
+	})).To(BeTrue(), "No rule found for group %q, port %#v. Actual %s", group, port, resource.ToJSON(t.rulesCreated))
+}
+
+func (t *testDriver) assertServerSecGroup(groupName string) {
+	secGroupFn := func(m map[string]any) bool {
+		return m["name"] == groupName
+	}
+
+	for _, s := range t.servers {
+		index := slices.IndexFunc(s.SecurityGroups, secGroupFn)
+		Expect(index).NotTo(BeNumerically("==", -1))
+		Expect(slices.IndexFunc(s.SecurityGroups[index+1:], secGroupFn)).To(BeNumerically("==", -1))
+	}
+}
+
+func (t *testDriver) assertNoServerSecGroup(groupName string) {
+	for _, s := range t.servers {
+		Expect(slices.ContainsFunc(s.SecurityGroups, func(m map[string]any) bool {
+			return m["name"] == groupName
+		})).To(BeFalse())
+	}
+}
+
+func (t *testDriver) testErrors(run func() error, entries ...any) {
+	params := []any{
+		func(message string, before func()) {
+			When(message+" fails", func() {
+				BeforeEach(func() {
+					before()
+				})
+
+				It("should return an error", func() {
+					Expect(run()).NotTo(Succeed())
+				})
+			})
+		},
+	}
+
+	DescribeTableSubtree("", append(params, entries...)...)
+}
+
+func newComputeV2ErrEntry() TableEntry {
+	return Entry("", "NewComputeV2", func() {
+		rhos.NewComputeV2 = func(_ *gophercloud.ProviderClient, _ gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+			return nil, errors.New("compute client error")
+		}
+	})
+}
+
+func newNetworkV2ErrEntry() TableEntry {
+	return Entry("", "NewNetworkV2", func() {
+		rhos.NewNetworkV2 = func(_ *gophercloud.ProviderClient, _ gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+			return nil, errors.New("network client error")
+		}
+	})
+}
+
+func createSecurityGroupErrEntry() TableEntry {
+	return Entry("", "CreateSecurityGroup", func() {
+		rhos.CreateSecurityGroup = func(_ *gophercloud.ServiceClient, _ secgroups.CreateOptsBuilder) (*secgroups.SecurityGroup, error) {
+			return nil, errors.New("create security group error")
+		}
+	})
+}
+
+func extractSecurityGroupsErrEntry() TableEntry {
+	return Entry("", "ExtractSecurityGroups", func() {
+		rhos.ExtractSecurityGroups = func(_ pagination.Page) ([]secgroups.SecurityGroup, error) {
+			return nil, errors.New("extract security groups error")
+		}
+	})
+}
+
+func extractServersErrEntry() TableEntry {
+	return Entry("", "ExtractServers", func() {
+		rhos.ExtractServers = func(page pagination.Page) ([]servers.Server, error) {
+			return nil, errors.New("extract servers error")
+		}
+	})
+}
+
+func addServerErrEntry() TableEntry {
+	return Entry("", "AddServer", func() {
+		rhos.AddServer = func(_ *gophercloud.ServiceClient, _, _ string) error {
+			return errors.New("add server error")
+		}
+	})
+}
+
+func deleteSecurityGroupErrEntry() TableEntry {
+	return Entry("", "DeleteSecurityGroup", func() {
+		rhos.DeleteSecurityGroup = func(_ *gophercloud.ServiceClient, _ string) secgroups.DeleteResult {
+			result := secgroups.DeleteResult{}
+			result.Err = errors.New("delete security group error")
+
+			return result
+		}
+	})
+}
+
+func removeServerErrEntry() TableEntry {
+	return Entry("", "RemoveServer", func() {
+		rhos.RemoveServer = func(_ *gophercloud.ServiceClient, _, _ string) error {
+			return errors.New("remove server error")
+		}
+	})
+}
+
+type EmptyPage struct{}
+
+func (p EmptyPage) NextPageURL() (string, error) {
+	return "", nil
+}
+
+func (p EmptyPage) IsEmpty() (bool, error) {
+	return true, nil
+}
+
+func (p EmptyPage) GetBody() any {
+	return nil
+}
+
+type SecGroupPage struct {
+	EmptyPage
+	secGroups []secgroups.SecurityGroup
+}
+
+type ServerPage struct {
+	EmptyPage
+	servers []servers.Server
+}
+
+type SubnetParam struct {
+	Filter SubnetFilter `json:"filter"`
+}
+type SubnetFilter struct {
+	Name string `json:"name,omitempty"`
+	Tags string `json:"tags,omitempty"`
+}

--- a/pkg/rhos/rhos_test.go
+++ b/pkg/rhos/rhos_test.go
@@ -1,0 +1,150 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rhos_test
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/secgroups"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	"github.com/submariner-io/cloud-prepare/pkg/k8s"
+	"github.com/submariner-io/cloud-prepare/pkg/rhos"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+var _ = Describe("Cloud", func() {
+	Context("OpenPorts", testOpenPorts)
+	Context("ClosePorts", testClosePorts)
+})
+
+func testOpenPorts() {
+	t := newRHOSTestDriver()
+
+	var ports []api.PortSpec
+
+	BeforeEach(func() {
+		ports = []api.PortSpec{
+			{
+				Port:     4500,
+				Protocol: "UDP",
+			},
+			{
+				Port:     500,
+				Protocol: "UDP",
+			},
+		}
+	})
+
+	When("the internal security group does not exist", func() {
+		It("should create the security group and open internal ports", func() {
+			Expect(t.cloud.OpenPorts(ports, reporter.Stdout())).To(Succeed())
+
+			Expect(t.securityGroupsCreated).To(ContainElement(internalSecurityGroup))
+
+			for _, port := range ports {
+				t.assertRuleCreated(rhos.InternalSecurityGroupSuffix, port)
+			}
+
+			t.assertServerSecGroup(internalSecurityGroup)
+		})
+	})
+
+	When("the internal security group already exists", func() {
+		BeforeEach(func() {
+			t.existingSecurityGroups = []secgroups.SecurityGroup{
+				{
+					Name: internalSecurityGroup,
+					ID:   internalSecurityGroup,
+				},
+			}
+		})
+
+		It("should not recreate it but should add servers to it", func() {
+			Expect(t.cloud.OpenPorts(ports, reporter.Stdout())).To(Succeed())
+
+			Expect(t.securityGroupsCreated).To(BeEmpty())
+			t.assertServerSecGroup(internalSecurityGroup)
+		})
+	})
+
+	t.testErrors(func() error { return t.cloud.OpenPorts(ports, reporter.Stdout()) },
+		newComputeV2ErrEntry(),
+		newNetworkV2ErrEntry(),
+		createSecurityGroupErrEntry(),
+		extractSecurityGroupsErrEntry(),
+		extractServersErrEntry(),
+		addServerErrEntry())
+}
+
+func testClosePorts() {
+	t := newRHOSTestDriver()
+
+	BeforeEach(func() {
+		t.existingSecurityGroups = []secgroups.SecurityGroup{
+			{
+				Name: internalSecurityGroup,
+				ID:   internalSecurityGroup,
+			},
+		}
+
+		t.servers[nodeName1].SecurityGroups = []map[string]any{
+			{"name": internalSecurityGroup},
+		}
+		t.servers[nodeName2].SecurityGroups = []map[string]any{
+			{"name": internalSecurityGroup},
+		}
+	})
+
+	It("should remove the security group from servers and delete it", func() {
+		Expect(t.cloud.ClosePorts(reporter.Stdout())).To(Succeed())
+
+		t.assertNoServerSecGroup(internalSecurityGroup)
+	})
+
+	t.testErrors(func() error { return t.cloud.ClosePorts(reporter.Stdout()) },
+		newComputeV2ErrEntry(),
+		deleteSecurityGroupErrEntry(),
+		extractSecurityGroupsErrEntry(),
+		extractServersErrEntry(),
+		removeServerErrEntry())
+}
+
+type rhosTestDriver struct {
+	*testDriver
+	cloud api.Cloud
+}
+
+func newRHOSTestDriver() *rhosTestDriver {
+	t := &rhosTestDriver{testDriver: newTestDriver()}
+
+	JustBeforeEach(func() {
+		info := rhos.CloudInfo{
+			Client:    &gophercloud.ProviderClient{},
+			InfraID:   testInfraID,
+			Region:    testRegion,
+			K8sClient: k8s.NewInterface(k8sfake.NewClientset()),
+		}
+
+		t.cloud = rhos.NewCloud(info)
+	})
+
+	return t
+}

--- a/pkg/rhos/securitygroups.go
+++ b/pkg/rhos/securitygroups.go
@@ -30,10 +30,11 @@ import (
 )
 
 type CloudInfo struct {
-	Client    *gophercloud.ProviderClient
-	InfraID   string
-	Region    string
-	K8sClient k8s.Interface
+	Client      *gophercloud.ProviderClient
+	InfraID     string
+	Region      string
+	SubnetNames []string
+	K8sClient   k8s.Interface
 }
 
 func (c *CloudInfo) openInternalPorts(infraID string, ports []api.PortSpec,

--- a/pkg/rhos/securitygroups.go
+++ b/pkg/rhos/securitygroups.go
@@ -29,6 +29,29 @@ import (
 	"github.com/submariner-io/cloud-prepare/pkg/k8s"
 )
 
+var (
+	ListSecurityGroups    = secgroups.List
+	ExtractSecurityGroups = secgroups.ExtractSecurityGroups
+	CreateSecurityGroup   = func(c *gophercloud.ServiceClient, opts secgroups.CreateOptsBuilder) (*secgroups.SecurityGroup, error) {
+		return secgroups.Create(c, opts).Extract()
+	}
+	DeleteSecurityGroup = secgroups.Delete
+	AddServer           = func(c *gophercloud.ServiceClient, serverID string, groupName string) error {
+		return secgroups.AddServer(c, serverID, groupName).ExtractErr()
+	}
+	RemoveServer = func(c *gophercloud.ServiceClient, serverID string, groupName string) error {
+		return secgroups.RemoveServer(c, serverID, groupName).ExtractErr()
+	}
+	EachPage = func(pager pagination.Pager, handler func(pagination.Page) (bool, error)) error {
+		return pager.EachPage(handler)
+	}
+	CreateRule = func(c *gophercloud.ServiceClient, opts rules.CreateOptsBuilder) (*rules.SecGroupRule, error) {
+		return rules.Create(c, opts).Extract()
+	}
+	ListServers    = servers.List
+	ExtractServers = servers.ExtractServers
+)
+
 type CloudInfo struct {
 	Client      *gophercloud.ProviderClient
 	InfraID     string
@@ -41,7 +64,7 @@ func (c *CloudInfo) openInternalPorts(infraID string, ports []api.PortSpec,
 	computeClient, networkClient *gophercloud.ServiceClient,
 ) error {
 	var group *secgroups.SecurityGroup
-	groupName := infraID + internalSecurityGroupSuffix
+	groupName := infraID + InternalSecurityGroupSuffix
 	opts := secgroups.CreateOpts{
 		Name:        groupName,
 		Description: "Submariner Internal",
@@ -53,7 +76,7 @@ func (c *CloudInfo) openInternalPorts(infraID string, ports []api.PortSpec,
 	}
 
 	if !isFound {
-		group, err = secgroups.Create(computeClient, opts).Extract()
+		group, err = CreateSecurityGroup(computeClient, opts)
 		if err != nil {
 			return errors.WithMessagef(err, "creating security group failed")
 		}
@@ -66,28 +89,31 @@ func (c *CloudInfo) openInternalPorts(infraID string, ports []api.PortSpec,
 		}
 	}
 
-	pager := servers.List(computeClient, servers.ListOpts{Name: c.InfraID})
-	err = pager.EachPage(func(page pagination.Page) (bool, error) {
-		serverList, err := servers.ExtractServers(page)
+	return addServerSecurityGroups(c.InfraID, groupName, computeClient)
+}
+
+func addServerSecurityGroups(serverName, groupName string, computeClient *gophercloud.ServiceClient) error {
+	pager := ListServers(computeClient, servers.ListOpts{Name: serverName})
+	err := EachPage(pager, func(page pagination.Page) (bool, error) {
+		serverList, err := ExtractServers(page)
 		if err != nil {
 			return false, errors.WithMessage(err, "getting the server List failed")
 		}
 
 		for i := range serverList {
 			found := false
-			securityGroups := serverList[i].SecurityGroups
 
-			for j := range securityGroups {
-				existingGroupName, ok := securityGroups[j]["name"]
+			for j := range serverList[i].SecurityGroups {
+				existingGroupName, ok := serverList[i].SecurityGroups[j]["name"]
 				if ok && existingGroupName == groupName {
 					found = true
 				}
 			}
 
 			if !found {
-				err := secgroups.AddServer(computeClient, serverList[i].ID, groupName).ExtractErr()
+				err = AddServer(computeClient, serverList[i].ID, groupName)
 				if err != nil {
-					return false, errors.WithMessage(err, "failed to add the security group to the server")
+					return false, errors.WithMessagef(err, "failed to add security group %q to server %s", groupName, serverList[i].ID)
 				}
 			}
 		}
@@ -95,32 +121,31 @@ func (c *CloudInfo) openInternalPorts(infraID string, ports []api.PortSpec,
 		return true, nil
 	})
 
-	return errors.WithMessagef(err, "failed to open ports")
+	return errors.WithMessage(err, "failed to add security group to servers")
 }
 
-func (c *CloudInfo) removeInternalFirewallRules(infraID string,
-	computeClient *gophercloud.ServiceClient,
-) error {
-	groupName := infraID + internalSecurityGroupSuffix
+func (c *CloudInfo) removeInternalFirewallRules(infraID string, computeClient *gophercloud.ServiceClient) error {
+	return removeServerSecurityGroups(c.InfraID, infraID+InternalSecurityGroupSuffix, computeClient)
+}
 
-	pager := servers.List(computeClient, servers.ListOpts{Name: c.InfraID})
+func removeServerSecurityGroups(serverName, groupName string, computeClient *gophercloud.ServiceClient) error {
+	pager := ListServers(computeClient, servers.ListOpts{Name: serverName})
 
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-		serverList, err := servers.ExtractServers(page)
+	err := EachPage(pager, func(page pagination.Page) (bool, error) {
+		serverList, err := ExtractServers(page)
 		if err != nil {
 			return false, errors.WithMessage(err, "getting the server List failed")
 		}
 
 		for i := range serverList {
-			err = secgroups.RemoveServer(computeClient, serverList[i].ID, groupName).ExtractErr()
+			err = RemoveServer(computeClient, serverList[i].ID, groupName)
 			if err != nil {
 				notFoundError := &gophercloud.ErrDefault404{}
 				if errors.As(err, notFoundError) {
 					continue
 				}
 
-				return false, errors.WithMessagef(err, "failed to remove the internal firewall for "+
-					"the server: %q ", serverList[i].Name)
+				return false, errors.WithMessagef(err, "failed to remove the firewall for the server: %q ", serverList[i].Name)
 			}
 		}
 
@@ -147,7 +172,7 @@ func (c *CloudInfo) createGWSecurityGroup(ports []api.PortSpec, groupName string
 		Description: "Submariner Gateway",
 	}
 
-	group, err := secgroups.Create(computeClient, opts).Extract()
+	group, err := CreateSecurityGroup(computeClient, opts)
 	if err != nil {
 		return errors.WithMessage(err, "failed to create g/w security group")
 	}
@@ -163,11 +188,11 @@ func (c *CloudInfo) createGWSecurityGroup(ports []api.PortSpec, groupName string
 }
 
 func checkIfSecurityGroupPresent(groupName string, computeClient *gophercloud.ServiceClient) (bool, error) {
-	pager := secgroups.List(computeClient)
+	pager := ListSecurityGroups(computeClient)
 	var isFound bool
 
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-		serverList, err := secgroups.ExtractSecurityGroups(page)
+	err := EachPage(pager, func(page pagination.Page) (bool, error) {
+		serverList, err := ExtractSecurityGroups(page)
 
 		for _, s := range serverList {
 			if s.Name == groupName {
@@ -181,74 +206,13 @@ func checkIfSecurityGroupPresent(groupName string, computeClient *gophercloud.Se
 	return isFound, errors.WithMessagef(err, "error getting the security group : %q", groupName)
 }
 
-func (c *CloudInfo) openGatewayPort(groupName, nodeName string, computeClient *gophercloud.ServiceClient) error {
-	opts := servers.ListOpts{Name: nodeName}
-	pager := servers.List(computeClient, opts)
-
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-		serverList, err := servers.ExtractServers(page)
-		if err != nil {
-			return false, errors.WithMessagef(err, "getting the server List failed for node %q", nodeName)
-		}
-
-		for i := range serverList {
-			securityGroups := serverList[i].SecurityGroups
-			for j := range securityGroups {
-				existingGroupName, ok := securityGroups[j]["name"]
-				if ok && existingGroupName == groupName {
-					return true, nil
-				}
-			}
-
-			err = secgroups.AddServer(computeClient, serverList[i].ID, groupName).ExtractErr()
-			if err != nil {
-				return false, errors.WithMessagef(err, "adding security group %q to the server %q failed",
-					groupName, serverList[i].Name)
-			}
-		}
-
-		return true, nil
-	})
-
-	return errors.WithMessagef(err, "open gateway ports failed")
-}
-
-func (c *CloudInfo) removeFirewallRulesFromGW(groupName, nodeName string, computeClient *gophercloud.ServiceClient) error {
-	opts := servers.ListOpts{Name: nodeName}
-	pager := servers.List(computeClient, opts)
-
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-		serverList, err := servers.ExtractServers(page)
-		if err != nil {
-			return false, errors.WithMessagef(err, "getting the server list failed")
-		}
-
-		for i := range serverList {
-			err = secgroups.RemoveServer(computeClient, serverList[i].ID, groupName).ExtractErr()
-			if err != nil {
-				notFoundError := &gophercloud.ErrDefault404{}
-				if errors.As(err, notFoundError) {
-					continue
-				}
-
-				return false, errors.WithMessagef(err, "failed to remove the firewall for"+
-					" the server: %q", serverList[i].Name)
-			}
-		}
-
-		return true, nil
-	})
-
-	return errors.WithMessagef(err, "removing firewall rules failed for security group %q", groupName)
-}
-
 func (c *CloudInfo) deleteSG(groupName string, computeClient *gophercloud.ServiceClient) error {
-	pager := secgroups.List(computeClient)
+	pager := ListSecurityGroups(computeClient)
 	var isFound bool
 	var securityGroupID string
 
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-		serverList, err := secgroups.ExtractSecurityGroups(page)
+	err := EachPage(pager, func(page pagination.Page) (bool, error) {
+		serverList, err := ExtractSecurityGroups(page)
 		if err != nil {
 			return false, errors.WithMessagef(err, "failed to list the security group %q", groupName)
 		}
@@ -266,7 +230,7 @@ func (c *CloudInfo) deleteSG(groupName string, computeClient *gophercloud.Servic
 	})
 
 	if err == nil && isFound {
-		err = secgroups.Delete(computeClient, securityGroupID).ExtractErr()
+		err = DeleteSecurityGroup(computeClient, securityGroupID).ExtractErr()
 	}
 
 	return errors.WithMessagef(err, "error deleting the security group %q", groupName)
@@ -286,7 +250,7 @@ func (c *CloudInfo) createSGRule(group, remoteGroupID, remoteIPPrefix string, po
 		RemoteIPPrefix: remoteIPPrefix,
 	}
 
-	_, err := rules.Create(networkClient, opts).Extract()
+	_, err := CreateRule(networkClient, opts)
 
 	return errors.WithMessagef(err, "failed creating security group rule with port %d , protocol %q,"+
 		"remotegroupID %q, remoteIPprefix %q , in security group %q", port, protocol, remoteGroupID, remoteIPPrefix, group)


### PR DESCRIPTION
Support multiple custom subnets in gateway machineset. This commit adds support for multiple subnets 
in the gateway machineset configuration. 


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway machine-sets can be configured with multiple subnets; single-subnet behavior remains as a fallback.

* **Improvements**
  * More consistent naming and handling for gateway/internal security groups and network operations.
  * Simplified and more reliable security group and server-association flows; reduced duplicate operations and clearer cleanup.

* **Tests**
  * Extensive test suite added covering deploy, cleanup, subnet permutations, security-group behavior, paginated API simulation, and error paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->