### PR TITLE
Automated backport of #1244: Add workflow to trigger CodeRabbit review for Bot PRs
#1247: Adjust CodeRabbit permissions to write pull_request
#1249: Add contents write permission to CodeRabbit workflow

### DIFF
--- a/.github/workflows/coderabbit-review.yml
+++ b/.github/workflows/coderabbit-review.yml
@@ -5,7 +5,7 @@ on:
     types: [opened]
 
 permissions:
-  issues: write
+  pull-requests: write
 
 jobs:
   trigger-review:

--- a/.github/workflows/coderabbit-review.yml
+++ b/.github/workflows/coderabbit-review.yml
@@ -1,0 +1,15 @@
+---
+name: Trigger CodeRabbit for Bot PRs
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  trigger-review:
+    uses: submariner-io/submariner-bot/.github/workflows/coderabbit-trigger.yml@devel
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets: inherit

--- a/.github/workflows/coderabbit-review.yml
+++ b/.github/workflows/coderabbit-review.yml
@@ -5,6 +5,7 @@ on:
     types: [opened]
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Backport of #1244 #1247 #1249 on release-0.19.

#1244: Add workflow to trigger CodeRabbit review for Bot PRs
#1247: Adjust CodeRabbit permissions to write pull_request
#1249: Add contents write permission to CodeRabbit workflow

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured GitHub Actions workflow to automatically trigger CodeRabbit code reviews for pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->