### PR TITLE
Consider preallocating slices with capacity

### DIFF
--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -72,7 +72,7 @@ func (az *azureCloud) ClosePorts(reporter reporterInterface.Interface) error {
 }
 
 func formatPorts(ports []api.PortSpec) string {
-	portStrs := []string{}
+	portStrs := make([]string, 0, len(ports))
 	for _, port := range ports {
 		portStrs = append(portStrs, fmt.Sprintf("%d/%s", port.Port, port.Protocol))
 	}

--- a/pkg/gcp/firewall_rules.go
+++ b/pkg/gcp/firewall_rules.go
@@ -64,7 +64,7 @@ func newInternalFirewallRule(projectID, infraID, network string, ports []api.Por
 }
 
 func newFirewallRule(projectID, name, direction, network string, ports []api.PortSpec) *compute.Firewall {
-	allowedPorts := []*compute.FirewallAllowed{}
+	allowedPorts := make([]*compute.FirewallAllowed, 0, len(ports))
 
 	for _, port := range ports {
 		fwRule := &compute.FirewallAllowed{

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -70,7 +70,7 @@ func (gc *gcpCloud) ClosePorts(status reporter.Interface) error {
 }
 
 func formatPorts(ports []api.PortSpec) string {
-	portStrs := []string{}
+	portStrs := make([]string, 0, len(ports))
 	for _, port := range ports {
 		portStrs = append(portStrs, fmt.Sprintf("%d/%s", port.Port, port.Protocol))
 	}

--- a/pkg/k8s/k8siface_test.go
+++ b/pkg/k8s/k8siface_test.go
@@ -252,7 +252,7 @@ func (t *interfaceTestDriver) assertNoLabel(name, key string) {
 }
 
 func assertNodeNames(list *corev1.NodeList, expNodes ...string) {
-	actual := []string{}
+	actual := make([]string, 0, len(list.Items))
 	nodes := list.Items
 
 	for i := range list.Items {

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -308,7 +308,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 }
 
 func formatPorts(ports []api.PortSpec) string {
-	portStrs := []string{}
+	portStrs := make([]string, 0, len(ports))
 	for _, port := range ports {
 		portStrs = append(portStrs, fmt.Sprintf("%d/%s", port.Port, port.Protocol))
 	}


### PR DESCRIPTION
...flagged by the 'prealloc' linter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized memory allocation efficiency across multiple components to reduce resource overhead and improve performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->