### PR TITLE
Fix error reporting in azure deployDedicatedGWNode

### DIFF
--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -21,6 +21,7 @@ package azure
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strconv"
 	"text/template"
 	"time"
@@ -139,7 +140,7 @@ func (d *ocpGatewayDeployer) deployDedicatedGWNode(gwNodes []unstructured.Unstru
 	airGapped bool, image string, status reporter.Interface,
 ) error {
 	az, err := d.getAvailabilityZones(gwNodes)
-	if err != nil || az.Len() == 0 {
+	if err != nil {
 		return status.Error(err, "error getting the availability zones for region %q", d.Region)
 	}
 
@@ -159,7 +160,8 @@ func (d *ocpGatewayDeployer) deployDedicatedGWNode(gwNodes []unstructured.Unstru
 	}
 
 	if gatewayNodesToDeploy != 0 {
-		return status.Error(err, "not enough zones available in the region %q to deploy required number of gateway nodes", d.Region)
+		return status.Error(fmt.Errorf("not enough zones available in the region %q to deploy required number of gateway nodes",
+			d.Region), "")
 	}
 
 	return nil


### PR DESCRIPTION
When `getAvailabilityZones` returns no zones, the return path was coupled with the error path so no error was returned. Remove the check for `az.Len() == 0` and let it fall through to the following code.

```
  if gatewayNodesToDeploy != 0 {
      return status.Error(err, "not enough zones available...", d.Region)
  }
```

However, this doesn't return an error either as `err` is nil. So create an error with the message and return via `status.Error`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and messaging when insufficient zones are available for gateway node deployment in Azure regions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->