### PR TITLE
Add ctx param to the cloud API methods and update implementations

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -18,7 +18,11 @@ limitations under the License.
 
 package api
 
-import "github.com/submariner-io/admiral/pkg/reporter"
+import (
+	"context"
+
+	"github.com/submariner-io/admiral/pkg/reporter"
+)
 
 // PortSpec is a specification of port+protocol to open.
 type PortSpec struct {
@@ -29,10 +33,10 @@ type PortSpec struct {
 // Cloud is a potential cloud for installing Submariner on.
 type Cloud interface {
 	// OpenPorts inside the cloud for submariner to communicate through.
-	OpenPorts(ports []PortSpec, status reporter.Interface) error
+	OpenPorts(ctx context.Context, ports []PortSpec, status reporter.Interface) error
 
 	// ClosePorts will close any internal ports that were opened, after Submariner is removed.
-	ClosePorts(status reporter.Interface) error
+	ClosePorts(ctx context.Context, status reporter.Interface) error
 }
 
 type GatewayDeployInput struct {
@@ -56,8 +60,8 @@ type GatewayDeployInput struct {
 // GatewayDeployer will deploy and cleanup dedicated gateways according to the requested policy.
 type GatewayDeployer interface {
 	// Deploy dedicated gateways as requested.
-	Deploy(input GatewayDeployInput, status reporter.Interface) error
+	Deploy(ctx context.Context, input GatewayDeployInput, status reporter.Interface) error
 
 	// Cleanup any dedicated gateways that were previously deployed.
-	Cleanup(status reporter.Interface) error
+	Cleanup(ctx context.Context, status reporter.Interface) error
 }

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -118,13 +118,13 @@ func NewCloudFromConfig(cfg *aws.Config, infraID, region string, opts ...CloudOp
 
 // NewCloudFromSettings creates a new api.Cloud instance using the given credentials file and profile
 // which can prepare AWS for Submariner to be deployed on it.
-func NewCloudFromSettings(credentialsFile, profile, infraID, region string, opts ...CloudOption) (api.Cloud, error) {
+func NewCloudFromSettings(ctx context.Context, credentialsFile, profile, infraID, region string, opts ...CloudOption) (api.Cloud, error) {
 	options := []func(*config.LoadOptions) error{config.WithRegion(region), config.WithSharedConfigProfile(profile)}
 	if credentialsFile != DefaultCredentialsFile() {
 		options = append(options, config.WithSharedCredentialsFiles([]string{credentialsFile}))
 	}
 
-	cfg, err := config.LoadDefaultConfig(context.TODO(), options...)
+	cfg, err := config.LoadDefaultConfig(ctx, options...)
 	if err != nil {
 		return nil, errors.Wrap(err, "error loading default config")
 	}
@@ -142,7 +142,7 @@ func DefaultProfile() string {
 	return "default"
 }
 
-func (ac *awsCloud) setSuffixes(vpcID string) error {
+func (ac *awsCloud) setSuffixes(ctx context.Context, vpcID string) error {
 	if ac.nodeSGSuffix != "" {
 		return nil
 	}
@@ -152,7 +152,7 @@ func (ac *awsCloud) setSuffixes(vpcID string) error {
 	if subnets, exists := ac.cloudConfig[PublicSubnetListKey]; exists {
 		if subnetIDs, ok := subnets.([]string); ok && len(subnetIDs) > 0 {
 			for _, id := range subnetIDs {
-				subnet, err := ac.getSubnetByID(id)
+				subnet, err := ac.getSubnetByID(ctx, id)
 				if err != nil {
 					return errors.Wrapf(err, "unable to find subnet with ID %s", id)
 				}
@@ -165,7 +165,7 @@ func (ac *awsCloud) setSuffixes(vpcID string) error {
 	} else {
 		var err error
 
-		publicSubnets, err = ac.findPublicSubnets(vpcID, ac.filterByName("{infraID}*-public-{region}*"))
+		publicSubnets, err = ac.findPublicSubnets(ctx, vpcID, ac.filterByName("{infraID}*-public-{region}*"))
 		if err != nil {
 			return errors.Wrapf(err, "unable to find the public subnet")
 		}
@@ -196,17 +196,17 @@ func (ac *awsCloud) setSuffixes(vpcID string) error {
 	return nil
 }
 
-func (ac *awsCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {
+func (ac *awsCloud) OpenPorts(ctx context.Context, ports []api.PortSpec, status reporter.Interface) error {
 	status.Start(messageRetrieveVPCID)
 	defer status.End()
 
-	vpcID, err := ac.getVpcID()
+	vpcID, err := ac.getVpcID(ctx)
 	if err != nil {
 		return status.Error(err, "unable to retrieve the VPC ID")
 	}
 
 	if _, found := ac.cloudConfig[VPCIDKey]; !found {
-		err = ac.setSuffixes(vpcID)
+		err = ac.setSuffixes(ctx, vpcID)
 		if err != nil {
 			return status.Error(err, "unable to retrieve the security group names")
 		}
@@ -216,7 +216,7 @@ func (ac *awsCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) e
 
 	status.Start(messageValidatePrerequisites)
 
-	err = ac.validatePreparePrerequisites(vpcID)
+	err = ac.validatePreparePrerequisites(ctx, vpcID)
 	if err != nil {
 		return status.Error(err, "unable to validate prerequisites")
 	}
@@ -226,7 +226,7 @@ func (ac *awsCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) e
 	for _, port := range ports {
 		status.Start("Opening port %v protocol %s for intra-cluster communications", port.Port, port.Protocol)
 
-		err = ac.allowPortInCluster(vpcID, port.Port, port.Protocol)
+		err = ac.allowPortInCluster(ctx, vpcID, port.Port, port.Protocol)
 		if err != nil {
 			return status.Error(err, "unable to open port")
 		}
@@ -237,21 +237,21 @@ func (ac *awsCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) e
 	return nil
 }
 
-func (ac *awsCloud) validatePreparePrerequisites(vpcID string) error {
-	return ac.validateCreateSecGroupRule(vpcID)
+func (ac *awsCloud) validatePreparePrerequisites(ctx context.Context, vpcID string) error {
+	return ac.validateCreateSecGroupRule(ctx, vpcID)
 }
 
-func (ac *awsCloud) ClosePorts(status reporter.Interface) error {
+func (ac *awsCloud) ClosePorts(ctx context.Context, status reporter.Interface) error {
 	status.Start(messageRetrieveVPCID)
 	defer status.End()
 
-	vpcID, err := ac.getVpcID()
+	vpcID, err := ac.getVpcID(ctx)
 	if err != nil {
 		return status.Error(err, "unable to retrieve the VPC ID")
 	}
 
 	if _, found := ac.cloudConfig[VPCIDKey]; !found {
-		err = ac.setSuffixes(vpcID)
+		err = ac.setSuffixes(ctx, vpcID)
 		if err != nil {
 			return status.Error(err, "unable to retrieve the security group names")
 		}
@@ -261,7 +261,7 @@ func (ac *awsCloud) ClosePorts(status reporter.Interface) error {
 
 	status.Start(messageValidatePrerequisites)
 
-	err = ac.validateCleanupPrerequisites(vpcID)
+	err = ac.validateCleanupPrerequisites(ctx, vpcID)
 	if err != nil {
 		return status.Error(err, "unable to validate prerequisites")
 	}
@@ -270,7 +270,7 @@ func (ac *awsCloud) ClosePorts(status reporter.Interface) error {
 
 	status.Start("Revoking intra-cluster communication permissions")
 
-	err = ac.revokePortsInCluster(vpcID)
+	err = ac.revokePortsInCluster(ctx, vpcID)
 	if err != nil {
 		return status.Error(err, "unable to revoke permissions")
 	}
@@ -280,6 +280,6 @@ func (ac *awsCloud) ClosePorts(status reporter.Interface) error {
 	return nil
 }
 
-func (ac *awsCloud) validateCleanupPrerequisites(vpcID string) error {
-	return ac.validateDeleteSecGroupRule(vpcID)
+func (ac *awsCloud) validateCleanupPrerequisites(ctx context.Context, vpcID string) error {
+	return ac.validateDeleteSecGroupRule(ctx, vpcID)
 }

--- a/pkg/aws/aws_cloud_test.go
+++ b/pkg/aws/aws_cloud_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package aws_test
 
 import (
+	"context"
 	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,7 +44,7 @@ func testOpenPorts() {
 		t.expectDescribeVpcsSigs(t.vpcID)
 		t.expectDescribePublicSubnets(t.subnets...)
 
-		retError = t.cloud.OpenPorts([]api.PortSpec{
+		retError = t.cloud.OpenPorts(context.TODO(), []api.PortSpec{
 			{
 				Port:     100,
 				Protocol: "TCP",
@@ -121,7 +122,7 @@ func testClosePorts() {
 		t.expectDescribePublicSubnets(t.subnets...)
 		t.expectDescribePublicSubnetsSigs(t.subnets...)
 
-		retError = t.cloud.ClosePorts(reporter.Stdout())
+		retError = t.cloud.ClosePorts(context.TODO(), reporter.Stdout())
 	})
 
 	Context("on success", func() {

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -126,8 +126,8 @@ func (ac *awsClient) DescribeInstanceTypeOfferings(ctx context.Context, input *e
 	return ac.ec2Client.DescribeInstanceTypeOfferings(ctx, input, optFns...)
 }
 
-func New(accessKeyID, secretAccessKey, region string) (Interface, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO(),
+func New(ctx context.Context, accessKeyID, secretAccessKey, region string) (Interface, error) {
+	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(region),
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")),
 		//nolint:staticcheck // WithEndpointResolverWithOptions is deprecated - needs to be migrated to EndpointResolverV2.

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -346,7 +346,7 @@ func (d *ocpGatewayDeployer) deployGateway(ctx context.Context, vpcID, gatewaySe
 		return err
 	}
 
-	return errors.Wrapf(d.msDeployer.Deploy(machineSet), "error deploying machine set %q", machineSet.GetName())
+	return errors.Wrapf(d.msDeployer.Deploy(ctx, machineSet), "error deploying machine set %q", machineSet.GetName())
 }
 
 func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interface) error {
@@ -456,5 +456,5 @@ func (d *ocpGatewayDeployer) deleteGateway(ctx context.Context, publicSubnet *ty
 		return err
 	}
 
-	return errors.Wrapf(d.msDeployer.Delete(machineSet), "error deleting machine set %q", machineSet.GetName())
+	return errors.Wrapf(d.msDeployer.Delete(ctx, machineSet), "error deleting machine set %q", machineSet.GetName())
 }

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -58,11 +58,11 @@ func NewOcpGatewayDeployer(cloud api.Cloud, msDeployer ocp.MachineSetDeployer, i
 	}, nil
 }
 
-func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeployInput, status reporter.Interface) error {
 	status.Start(messageRetrieveVPCID)
 	defer status.End()
 
-	vpcID, err := d.aws.getVpcID()
+	vpcID, err := d.aws.getVpcID(ctx)
 	if err != nil {
 		return status.Error(err, "unable to retrieve the VPC ID")
 	}
@@ -70,7 +70,7 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 	status.Success(messageRetrievedVPCID, vpcID)
 
 	if _, found := d.aws.cloudConfig[VPCIDKey]; !found {
-		err = d.aws.setSuffixes(vpcID)
+		err = d.aws.setSuffixes(ctx, vpcID)
 		if err != nil {
 			return status.Error(err, "unable to retrieve the security group names")
 		}
@@ -83,7 +83,7 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 	if subnets, exists := d.aws.cloudConfig[PublicSubnetListKey]; exists {
 		if subnetIDs, ok := subnets.([]string); ok && len(subnetIDs) > 0 {
 			for _, id := range subnetIDs {
-				subnet, err := d.aws.getSubnetByID(id)
+				subnet, err := d.aws.getSubnetByID(ctx, id)
 				if err != nil {
 					return errors.Wrapf(err, "unable to find subnet with ID %s", id)
 				}
@@ -94,13 +94,13 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 			return errors.New("Subnet IDs must be a valid non-empty slice of strings")
 		}
 	} else {
-		publicSubnets, err = d.aws.findPublicSubnets(vpcID, d.aws.filterByName("{infraID}*-public-{region}*"))
+		publicSubnets, err = d.aws.findPublicSubnets(ctx, vpcID, d.aws.filterByName("{infraID}*-public-{region}*"))
 		if err != nil {
 			return status.Error(err, "unable to find public subnets")
 		}
 	}
 
-	err = d.validateDeployPrerequisites(vpcID, input, publicSubnets)
+	err = d.validateDeployPrerequisites(ctx, vpcID, input, publicSubnets)
 	if err != nil {
 		return status.Error(err, "unable to validate prerequisites")
 	}
@@ -109,20 +109,20 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 
 	status.Start("Creating Submariner gateway security group")
 
-	gatewaySG, err := d.aws.createGatewaySG(vpcID, input.PublicPorts)
+	gatewaySG, err := d.aws.createGatewaySG(ctx, vpcID, input.PublicPorts)
 	if err != nil {
 		return status.Error(err, "unable to create gateway")
 	}
 
 	status.Success("Created Submariner gateway security group %s", gatewaySG)
 
-	return d.processSubnets(vpcID, gatewaySG, publicSubnets, input, status)
+	return d.processSubnets(ctx, vpcID, gatewaySG, publicSubnets, input, status)
 }
 
-func (d *ocpGatewayDeployer) processSubnets(vpcID, gatewaySG string, publicSubnets []types.Subnet,
+func (d *ocpGatewayDeployer) processSubnets(ctx context.Context, vpcID, gatewaySG string, publicSubnets []types.Subnet,
 	input api.GatewayDeployInput, status reporter.Interface,
 ) error {
-	subnets, err := d.aws.getSubnetsSupportingInstanceType(publicSubnets, d.instanceType)
+	subnets, err := d.aws.getSubnetsSupportingInstanceType(ctx, publicSubnets, d.instanceType)
 	if err != nil {
 		return status.Error(err, "unable to get subnets supporting instance type")
 	}
@@ -145,7 +145,7 @@ func (d *ocpGatewayDeployer) processSubnets(vpcID, gatewaySG string, publicSubne
 
 		status.Start("Adjusting public subnet %s to support Submariner", subnetName)
 
-		err = d.aws.tagPublicSubnet(subnet.SubnetId)
+		err = d.aws.tagPublicSubnet(ctx, subnet.SubnetId)
 		if err != nil {
 			return status.Error(err, "unable to tag public subnet")
 		}
@@ -161,7 +161,7 @@ func (d *ocpGatewayDeployer) processSubnets(vpcID, gatewaySG string, publicSubne
 
 		status.Start("Deploying gateway node for public subnet %s", subnetName)
 
-		err = d.deployGateway(vpcID, gatewaySG, subnet)
+		err = d.deployGateway(ctx, vpcID, gatewaySG, subnet)
 		if err != nil {
 			return status.Error(err, "unable to deploy gateway")
 		}
@@ -172,15 +172,15 @@ func (d *ocpGatewayDeployer) processSubnets(vpcID, gatewaySG string, publicSubne
 	return nil
 }
 
-func (d *ocpGatewayDeployer) validateDeployPrerequisites(vpcID string, input api.GatewayDeployInput,
+func (d *ocpGatewayDeployer) validateDeployPrerequisites(ctx context.Context, vpcID string, input api.GatewayDeployInput,
 	publicSubnets []types.Subnet,
 ) error {
 	var errs []error
 	var subnets []types.Subnet
 
-	errs = appendIfError(errs, d.aws.validateCreateSecGroup(vpcID))
-	errs = appendIfError(errs, d.aws.validateCreateSecGroupRule(vpcID))
-	err := d.aws.validateDescribeInstanceTypeOfferings()
+	errs = appendIfError(errs, d.aws.validateCreateSecGroup(ctx, vpcID))
+	errs = appendIfError(errs, d.aws.validateCreateSecGroupRule(ctx, vpcID))
+	err := d.aws.validateDescribeInstanceTypeOfferings(ctx)
 	errs = appendIfError(errs, err)
 
 	if err != nil {
@@ -190,7 +190,7 @@ func (d *ocpGatewayDeployer) validateDeployPrerequisites(vpcID string, input api
 	// If instanceType is not specified, auto-select the most suitable one.
 	if d.instanceType == "" {
 		for _, instanceType := range PreferredInstances {
-			subnets, err = d.aws.getSubnetsSupportingInstanceType(publicSubnets, instanceType)
+			subnets, err = d.aws.getSubnetsSupportingInstanceType(ctx, publicSubnets, instanceType)
 			if err != nil {
 				return err
 			}
@@ -201,7 +201,7 @@ func (d *ocpGatewayDeployer) validateDeployPrerequisites(vpcID string, input api
 			}
 		}
 	} else {
-		subnets, err = d.aws.getSubnetsSupportingInstanceType(publicSubnets, d.instanceType)
+		subnets, err = d.aws.getSubnetsSupportingInstanceType(ctx, publicSubnets, d.instanceType)
 		if err != nil {
 			return err
 		}
@@ -214,7 +214,7 @@ func (d *ocpGatewayDeployer) validateDeployPrerequisites(vpcID string, input api
 	}
 
 	if len(subnets) > 0 {
-		errs = appendIfError(errs, d.aws.validateCreateTag(*subnets[0].SubnetId))
+		errs = appendIfError(errs, d.aws.validateCreateTag(ctx, *subnets[0].SubnetId))
 	}
 
 	return goerrors.Join(errs...)
@@ -231,13 +231,13 @@ type machineSetConfig struct {
 	NodeSG        string
 }
 
-func (d *ocpGatewayDeployer) findAMIID(vpcID string) (string, error) {
+func (d *ocpGatewayDeployer) findAMIID(ctx context.Context, vpcID string) (string, error) {
 	ownedFilters := d.aws.filterByCurrentCluster()
 	var err error
 	var result *ec2.DescribeInstancesOutput
 
 	for i := range ownedFilters {
-		result, err = d.aws.client.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{
+		result, err = d.aws.client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 			Filters: []types.Filter{
 				ec2Filter("vpc-id", vpcID),
 				d.aws.filterByName("{infraID}-worker*"),
@@ -268,7 +268,9 @@ func (d *ocpGatewayDeployer) findAMIID(vpcID string) (string, error) {
 	return *result.Reservations[0].Instances[0].ImageId, nil
 }
 
-func (d *ocpGatewayDeployer) loadGatewayYAML(gatewaySecurityGroup, amiID string, publicSubnet *types.Subnet) ([]byte, error) {
+func (d *ocpGatewayDeployer) loadGatewayYAML(ctx context.Context, gatewaySecurityGroup, amiID string,
+	publicSubnet *types.Subnet,
+) ([]byte, error) {
 	var buf bytes.Buffer
 
 	tpl, err := template.New("").Parse(machineSetYAML)
@@ -288,7 +290,7 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(gatewaySecurityGroup, amiID string,
 
 	if id, exists := d.aws.cloudConfig[WorkerSecurityGroupIDKey]; exists {
 		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
-			workerSecurityGroup, err := d.aws.getSecurityGroupByID(workerGroupIDStr)
+			workerSecurityGroup, err := d.aws.getSecurityGroupByID(ctx, workerGroupIDStr)
 			if err != nil {
 				return nil, errors.Wrapf(err, "error finding the worker security group with ID %s", workerGroupIDStr)
 			}
@@ -313,8 +315,10 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(gatewaySecurityGroup, amiID string,
 	return buf.Bytes(), nil
 }
 
-func (d *ocpGatewayDeployer) initMachineSet(gwSecurityGroup, amiID string, publicSubnet *types.Subnet) (*unstructured.Unstructured, error) {
-	gatewayYAML, err := d.loadGatewayYAML(gwSecurityGroup, amiID, publicSubnet)
+func (d *ocpGatewayDeployer) initMachineSet(ctx context.Context, gwSecurityGroup, amiID string,
+	publicSubnet *types.Subnet,
+) (*unstructured.Unstructured, error) {
+	gatewayYAML, err := d.loadGatewayYAML(ctx, gwSecurityGroup, amiID, publicSubnet)
 	if err != nil {
 		return nil, err
 	}
@@ -331,13 +335,13 @@ func (d *ocpGatewayDeployer) initMachineSet(gwSecurityGroup, amiID string, publi
 	return machineSet, nil
 }
 
-func (d *ocpGatewayDeployer) deployGateway(vpcID, gatewaySecurityGroup string, publicSubnet *types.Subnet) error {
-	amiID, err := d.findAMIID(vpcID)
+func (d *ocpGatewayDeployer) deployGateway(ctx context.Context, vpcID, gatewaySecurityGroup string, publicSubnet *types.Subnet) error {
+	amiID, err := d.findAMIID(ctx, vpcID)
 	if err != nil {
 		return err
 	}
 
-	machineSet, err := d.initMachineSet(gatewaySecurityGroup, amiID, publicSubnet)
+	machineSet, err := d.initMachineSet(ctx, gatewaySecurityGroup, amiID, publicSubnet)
 	if err != nil {
 		return err
 	}
@@ -345,11 +349,11 @@ func (d *ocpGatewayDeployer) deployGateway(vpcID, gatewaySecurityGroup string, p
 	return errors.Wrapf(d.msDeployer.Deploy(machineSet), "error deploying machine set %q", machineSet.GetName())
 }
 
-func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interface) error {
 	status.Start(messageRetrieveVPCID)
 	defer status.End()
 
-	vpcID, err := d.aws.getVpcID()
+	vpcID, err := d.aws.getVpcID(ctx)
 	if err != nil {
 		return status.Error(err, "unable to retrieve the VPC ID")
 	}
@@ -357,7 +361,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 	status.Success(messageRetrievedVPCID, vpcID)
 
 	if _, found := d.aws.cloudConfig[VPCIDKey]; !found {
-		err = d.aws.setSuffixes(vpcID)
+		err = d.aws.setSuffixes(ctx, vpcID)
 		if err != nil {
 			return status.Error(err, "unable to retrieve the security group names")
 		}
@@ -365,7 +369,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 
 	status.Start(messageValidatePrerequisites)
 
-	err = d.validateCleanupPrerequisites(vpcID)
+	err = d.validateCleanupPrerequisites(ctx, vpcID)
 	if err != nil {
 		return status.Error(err, "unable to validate prerequisites")
 	}
@@ -377,7 +381,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 	if subnets, exists := d.aws.cloudConfig[PublicSubnetListKey]; exists {
 		if subnetIDs, ok := subnets.([]string); ok && len(subnetIDs) > 0 {
 			for _, id := range subnetIDs {
-				subnet, err := d.aws.getSubnetByID(id)
+				subnet, err := d.aws.getSubnetByID(ctx, id)
 				if err != nil {
 					return errors.Wrapf(err, "unable to find subnet with ID %s", id)
 				}
@@ -388,7 +392,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 			return errors.New("Subnet IDs must be a valid non-empty slice of strings")
 		}
 	} else {
-		publicSubnets, err = d.aws.getTaggedPublicSubnets(vpcID)
+		publicSubnets, err = d.aws.getTaggedPublicSubnets(ctx, vpcID)
 		if err != nil {
 			return err
 		}
@@ -400,7 +404,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 
 		status.Start("Removing gateway node for public subnet %s", subnetName)
 
-		err = d.deleteGateway(subnet)
+		err = d.deleteGateway(ctx, subnet)
 		if err != nil {
 			return status.Error(err, "unable to remove gateway node")
 		}
@@ -409,7 +413,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 
 		status.Start("Untagging public subnet %s from supporting Submariner", subnetName)
 
-		err = d.aws.untagPublicSubnet(subnet.SubnetId)
+		err = d.aws.untagPublicSubnet(ctx, subnet.SubnetId)
 		if err != nil {
 			return status.Error(err, "unable to untag subnet")
 		}
@@ -419,7 +423,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 
 	status.Start("Deleting Submariner gateway security group")
 
-	err = d.aws.deleteGatewaySG(vpcID)
+	err = d.aws.deleteGatewaySG(ctx, vpcID)
 	if err != nil {
 		return status.Error(err, "unable to delete gateway")
 	}
@@ -429,25 +433,25 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 	return nil
 }
 
-func (d *ocpGatewayDeployer) validateCleanupPrerequisites(vpcID string) error {
+func (d *ocpGatewayDeployer) validateCleanupPrerequisites(ctx context.Context, vpcID string) error {
 	var errs []error
 
-	errs = appendIfError(errs, d.aws.validateDeleteSecGroup(vpcID))
+	errs = appendIfError(errs, d.aws.validateDeleteSecGroup(ctx, vpcID))
 
-	subnets, err := d.aws.getTaggedPublicSubnets(vpcID)
+	subnets, err := d.aws.getTaggedPublicSubnets(ctx, vpcID)
 	if err != nil {
 		return err
 	}
 
 	if len(subnets) > 0 {
-		errs = appendIfError(errs, d.aws.validateRemoveTag(subnets[0].SubnetId))
+		errs = appendIfError(errs, d.aws.validateRemoveTag(ctx, subnets[0].SubnetId))
 	}
 
 	return goerrors.Join(errs...)
 }
 
-func (d *ocpGatewayDeployer) deleteGateway(publicSubnet *types.Subnet) error {
-	machineSet, err := d.initMachineSet("", "", publicSubnet)
+func (d *ocpGatewayDeployer) deleteGateway(ctx context.Context, publicSubnet *types.Subnet) error {
+	machineSet, err := d.initMachineSet(ctx, "", "", publicSubnet)
 	if err != nil {
 		return err
 	}

--- a/pkg/aws/ocpgwdeployer_test.go
+++ b/pkg/aws/ocpgwdeployer_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package aws_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -305,7 +306,7 @@ func (t *gatewayDeployerTestDriver) expectedInstanceType() string {
 }
 
 func (t *gatewayDeployerTestDriver) doDeploy() {
-	t.retError = t.gwDeployer.Deploy(api.GatewayDeployInput{
+	t.retError = t.gwDeployer.Deploy(context.TODO(), api.GatewayDeployInput{
 		Gateways: t.numGateways,
 		PublicPorts: []api.PortSpec{
 			{
@@ -321,7 +322,7 @@ func (t *gatewayDeployerTestDriver) doDeploy() {
 }
 
 func (t *gatewayDeployerTestDriver) doCleanup() {
-	t.retError = t.gwDeployer.Cleanup(reporter.Stdout())
+	t.retError = t.gwDeployer.Cleanup(context.TODO(), reporter.Stdout())
 }
 
 func (t *gatewayDeployerTestDriver) expectDeployValidations(enforce bool) {

--- a/pkg/aws/ocpgwdeployer_test.go
+++ b/pkg/aws/ocpgwdeployer_test.go
@@ -46,7 +46,7 @@ func testDeploy() {
 	var deployCall *mock.Call
 
 	JustBeforeEach(func() {
-		deployCall = t.msDeployer.EXPECT().Deploy(mock.Anything).RunAndReturn(machineSetFn(&t.machineSets)).Call
+		deployCall = t.msDeployer.EXPECT().Deploy(mock.Anything, mock.Anything).RunAndReturn(machineSetFn(&t.machineSets)).Call
 
 		t.expectDescribePublicSubnets(t.subnets...)
 
@@ -196,7 +196,7 @@ func testCleanup() {
 	When("on success", func() {
 		BeforeEach(func() {
 			t.expectCleanupValidations(true)
-			t.msDeployer.EXPECT().Delete(mock.Anything).RunAndReturn(machineSetFn(&t.machineSets)).Times(len(t.subnets))
+			t.msDeployer.EXPECT().Delete(mock.Anything, mock.Anything).RunAndReturn(machineSetFn(&t.machineSets)).Times(len(t.subnets))
 			t.expectDeleteSecurityGroup(gatewayGroupID)
 
 			for i := range t.subnets {
@@ -375,10 +375,10 @@ func (t *gatewayDeployerTestDriver) testDeploySuccess(msgPrefix, msgSuffix strin
 }
 
 //nolint:gocritic // Error: "consider `machineSets' to be of non-pointer type"
-func machineSetFn(machineSets *map[string]*unstructured.Unstructured) func(ms *unstructured.Unstructured) error {
+func machineSetFn(machineSets *map[string]*unstructured.Unstructured) func(_ context.Context, ms *unstructured.Unstructured) error {
 	*machineSets = map[string]*unstructured.Unstructured{}
 
-	return func(ms *unstructured.Unstructured) error {
+	return func(_ context.Context, ms *unstructured.Unstructured) error {
 		zone, ok, _ := unstructured.NestedString(ms.Object, "spec", "template", "spec", "providerSpec", "value",
 			"placement", "availabilityZone")
 		Expect(ok).To(BeTrue())

--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -34,8 +34,8 @@ import (
 
 const internalTraffic = "Internal Submariner traffic"
 
-func (ac *awsCloud) getSecurityGroupName(vpcID, name string) (*string, error) {
-	group, err := ac.getSecurityGroup(vpcID, name)
+func (ac *awsCloud) getSecurityGroupName(ctx context.Context, vpcID, name string) (*string, error) {
+	group, err := ac.getSecurityGroup(ctx, vpcID, name)
 	if err != nil {
 		return nil, err
 	}
@@ -43,8 +43,8 @@ func (ac *awsCloud) getSecurityGroupName(vpcID, name string) (*string, error) {
 	return group.GroupId, nil
 }
 
-func (ac *awsCloud) getSecurityGroupByID(groupID string) (types.SecurityGroup, error) {
-	output, err := ac.client.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{
+func (ac *awsCloud) getSecurityGroupByID(ctx context.Context, groupID string) (types.SecurityGroup, error) {
+	output, err := ac.client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
 		GroupIds: []string{groupID},
 	})
 	if err != nil {
@@ -58,13 +58,13 @@ func (ac *awsCloud) getSecurityGroupByID(groupID string) (types.SecurityGroup, e
 	return output.SecurityGroups[0], nil
 }
 
-func (ac *awsCloud) getSecurityGroup(vpcID, name string) (types.SecurityGroup, error) {
+func (ac *awsCloud) getSecurityGroup(ctx context.Context, vpcID, name string) (types.SecurityGroup, error) {
 	filters := []types.Filter{
 		ec2Filter("vpc-id", vpcID),
 		ac.filterByName(name),
 	}
 
-	result, err := ac.client.DescribeSecurityGroups(context.TODO(), &ec2.DescribeSecurityGroupsInput{
+	result, err := ac.client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
 		Filters: filters,
 	})
 	if err != nil {
@@ -78,13 +78,13 @@ func (ac *awsCloud) getSecurityGroup(vpcID, name string) (types.SecurityGroup, e
 	return result.SecurityGroups[0], nil
 }
 
-func (ac *awsCloud) authorizeSecurityGroupIngress(groupID *string, ipPermissions []types.IpPermission) error {
+func (ac *awsCloud) authorizeSecurityGroupIngress(ctx context.Context, groupID *string, ipPermissions []types.IpPermission) error {
 	input := &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId:       groupID,
 		IpPermissions: ipPermissions,
 	}
 
-	_, err := ac.client.AuthorizeSecurityGroupIngress(context.TODO(), input)
+	_, err := ac.client.AuthorizeSecurityGroupIngress(ctx, input)
 	if isAWSError(err, "InvalidPermission.Duplicate") {
 		return nil
 	}
@@ -92,7 +92,7 @@ func (ac *awsCloud) authorizeSecurityGroupIngress(groupID *string, ipPermissions
 	return errors.Wrap(err, "error authorizing AWS security groups ingress")
 }
 
-func (ac *awsCloud) createClusterSGRule(srcGroup, destGroup *string, port uint16, protocol, description string) error {
+func (ac *awsCloud) createClusterSGRule(ctx context.Context, srcGroup, destGroup *string, port uint16, protocol, description string) error {
 	ipPermissions := []types.IpPermission{
 		{
 			FromPort:   ptr.To(int32(port)),
@@ -107,10 +107,10 @@ func (ac *awsCloud) createClusterSGRule(srcGroup, destGroup *string, port uint16
 		},
 	}
 
-	return ac.authorizeSecurityGroupIngress(destGroup, ipPermissions)
+	return ac.authorizeSecurityGroupIngress(ctx, destGroup, ipPermissions)
 }
 
-func (ac *awsCloud) allowPortInCluster(vpcID string, port uint16, protocol string) error {
+func (ac *awsCloud) allowPortInCluster(ctx context.Context, vpcID string, port uint16, protocol string) error {
 	var workerGroupID, controlPlaneGroupID *string
 	var err error
 
@@ -123,7 +123,7 @@ func (ac *awsCloud) allowPortInCluster(vpcID string, port uint16, protocol strin
 	} else {
 		workerGroupName := withInfraIDPrefix(ac.nodeSGSuffix)
 
-		workerGroupID, err = ac.getSecurityGroupName(vpcID, workerGroupName)
+		workerGroupID, err = ac.getSecurityGroupName(ctx, vpcID, workerGroupName)
 		if err != nil {
 			return err
 		}
@@ -138,28 +138,28 @@ func (ac *awsCloud) allowPortInCluster(vpcID string, port uint16, protocol strin
 	} else {
 		controlPlaneGroupName := withInfraIDPrefix(ac.controlPlaneSGSuffix)
 
-		controlPlaneGroupID, err = ac.getSecurityGroupName(vpcID, controlPlaneGroupName)
+		controlPlaneGroupID, err = ac.getSecurityGroupName(ctx, vpcID, controlPlaneGroupName)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = ac.createClusterSGRule(workerGroupID, workerGroupID, port, protocol, internalTraffic+" between the workers")
+	err = ac.createClusterSGRule(ctx, workerGroupID, workerGroupID, port, protocol, internalTraffic+" between the workers")
 	if err != nil {
 		return err
 	}
 
-	err = ac.createClusterSGRule(workerGroupID, controlPlaneGroupID, port, protocol,
+	err = ac.createClusterSGRule(ctx, workerGroupID, controlPlaneGroupID, port, protocol,
 		internalTraffic+" from worker to control plane nodes")
 	if err != nil {
 		return err
 	}
 
-	return ac.createClusterSGRule(controlPlaneGroupID, workerGroupID, port, protocol,
+	return ac.createClusterSGRule(ctx, controlPlaneGroupID, workerGroupID, port, protocol,
 		internalTraffic+" from control plane to worker nodes")
 }
 
-func (ac *awsCloud) createPublicSGRule(groupID *string, port uint16, protocol, description string) error {
+func (ac *awsCloud) createPublicSGRule(ctx context.Context, groupID *string, port uint16, protocol, description string) error {
 	ipPermissions := []types.IpPermission{
 		{
 			FromPort:   ptr.To(int32(port)),
@@ -174,13 +174,13 @@ func (ac *awsCloud) createPublicSGRule(groupID *string, port uint16, protocol, d
 		},
 	}
 
-	return ac.authorizeSecurityGroupIngress(groupID, ipPermissions)
+	return ac.authorizeSecurityGroupIngress(ctx, groupID, ipPermissions)
 }
 
-func (ac *awsCloud) createGatewaySG(vpcID string, ports []api.PortSpec) (string, error) {
+func (ac *awsCloud) createGatewaySG(ctx context.Context, vpcID string, ports []api.PortSpec) (string, error) {
 	groupName := ac.withAWSInfo(withInfraIDPrefix("-submariner-gw-sg"))
 
-	gatewayGroupID, err := ac.getSecurityGroupName(vpcID, groupName)
+	gatewayGroupID, err := ac.getSecurityGroupName(ctx, vpcID, groupName)
 	if err != nil {
 		if !isNotFoundError(err) {
 			return "", err
@@ -201,7 +201,7 @@ func (ac *awsCloud) createGatewaySG(vpcID string, ports []api.PortSpec) (string,
 			},
 		}
 
-		result, err := ac.client.CreateSecurityGroup(context.TODO(), input)
+		result, err := ac.client.CreateSecurityGroup(ctx, input)
 
 		if err != nil && !isAWSError(err, "InvalidGroup.Duplicate") {
 			return "", errors.Wrap(err, "error creating AWS security group")
@@ -211,7 +211,7 @@ func (ac *awsCloud) createGatewaySG(vpcID string, ports []api.PortSpec) (string,
 	}
 
 	for _, port := range ports {
-		err = ac.createPublicSGRule(gatewayGroupID, port.Port, port.Protocol, "Public Submariner traffic")
+		err = ac.createPublicSGRule(ctx, gatewayGroupID, port.Port, port.Protocol, "Public Submariner traffic")
 		if err != nil {
 			return "", err
 		}
@@ -224,10 +224,10 @@ func gatewayDeletionRetriable(err error) bool {
 	return isAWSError(err, "DependencyViolation")
 }
 
-func (ac *awsCloud) deleteGatewaySG(vpcID string) error {
+func (ac *awsCloud) deleteGatewaySG(ctx context.Context, vpcID string) error {
 	groupName := ac.withAWSInfo(withInfraIDPrefix("-submariner-gw-sg"))
 
-	gatewayGroupID, err := ac.getSecurityGroupName(vpcID, groupName)
+	gatewayGroupID, err := ac.getSecurityGroupName(ctx, vpcID, groupName)
 	if err != nil {
 		if isNotFoundError(err) {
 			return nil
@@ -244,7 +244,7 @@ func (ac *awsCloud) deleteGatewaySG(vpcID string) error {
 	}
 
 	err = retry.OnError(backoff, gatewayDeletionRetriable, func() error {
-		_, err = ac.client.DeleteSecurityGroup(context.TODO(), &ec2.DeleteSecurityGroupInput{
+		_, err = ac.client.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{
 			GroupId: gatewayGroupID,
 		})
 
@@ -258,13 +258,13 @@ func (ac *awsCloud) deleteGatewaySG(vpcID string) error {
 	return errors.Wrap(err, "error deleting AWS security group")
 }
 
-func (ac *awsCloud) revokePortsInCluster(vpcID string) error {
+func (ac *awsCloud) revokePortsInCluster(ctx context.Context, vpcID string) error {
 	var workerGroup, controlPlaneGroup types.SecurityGroup
 	var err error
 
 	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
 		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
-			workerGroup, err = ac.getSecurityGroupByID(workerGroupIDStr)
+			workerGroup, err = ac.getSecurityGroupByID(ctx, workerGroupIDStr)
 			if err != nil {
 				return errors.Wrap(err, "unable to get Worker Security Group by ID")
 			}
@@ -274,7 +274,7 @@ func (ac *awsCloud) revokePortsInCluster(vpcID string) error {
 	} else {
 		workerGroupName := withInfraIDPrefix(ac.nodeSGSuffix)
 
-		workerGroup, err = ac.getSecurityGroup(vpcID, workerGroupName)
+		workerGroup, err = ac.getSecurityGroup(ctx, vpcID, workerGroupName)
 		if err != nil {
 			return err
 		}
@@ -282,7 +282,7 @@ func (ac *awsCloud) revokePortsInCluster(vpcID string) error {
 
 	if id, exists := ac.cloudConfig[ControlPlaneSecurityGroupIDKey]; exists {
 		if controlPlaneGroupIDStr, ok := id.(string); ok && controlPlaneGroupIDStr != "" {
-			controlPlaneGroup, err = ac.getSecurityGroupByID(controlPlaneGroupIDStr)
+			controlPlaneGroup, err = ac.getSecurityGroupByID(ctx, controlPlaneGroupIDStr)
 			if err != nil {
 				return errors.Wrap(err, "unable to get Control Plane Security Group by ID")
 			}
@@ -292,21 +292,21 @@ func (ac *awsCloud) revokePortsInCluster(vpcID string) error {
 	} else {
 		controlPlaneGroupName := withInfraIDPrefix(ac.controlPlaneSGSuffix)
 
-		controlPlaneGroup, err = ac.getSecurityGroup(vpcID, controlPlaneGroupName)
+		controlPlaneGroup, err = ac.getSecurityGroup(ctx, vpcID, controlPlaneGroupName)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = ac.revokePortsFromGroup(&workerGroup)
+	err = ac.revokePortsFromGroup(ctx, &workerGroup)
 	if err != nil {
 		return err
 	}
 
-	return ac.revokePortsFromGroup(&controlPlaneGroup)
+	return ac.revokePortsFromGroup(ctx, &controlPlaneGroup)
 }
 
-func (ac *awsCloud) revokePortsFromGroup(group *types.SecurityGroup) error {
+func (ac *awsCloud) revokePortsFromGroup(ctx context.Context, group *types.SecurityGroup) error {
 	var permissionsToRevoke []types.IpPermission
 
 	for perm := range group.IpPermissions {
@@ -328,7 +328,7 @@ func (ac *awsCloud) revokePortsFromGroup(group *types.SecurityGroup) error {
 		IpPermissions: permissionsToRevoke,
 	}
 
-	_, err := ac.client.RevokeSecurityGroupIngress(context.TODO(), input)
+	_, err := ac.client.RevokeSecurityGroupIngress(ctx, input)
 
 	return errors.Wrap(err, "error revoking AWS security group ingress")
 }

--- a/pkg/aws/subnets.go
+++ b/pkg/aws/subnets.go
@@ -54,7 +54,7 @@ func subnetTagged(subnet *types.Subnet) bool {
 	return hasTag(subnet.Tags, tagSubmarinerGateway)
 }
 
-func (ac *awsCloud) findPublicSubnets(vpcID string, filter types.Filter) ([]types.Subnet, error) {
+func (ac *awsCloud) findPublicSubnets(ctx context.Context, vpcID string, filter types.Filter) ([]types.Subnet, error) {
 	ownedFilters := ac.filterByCurrentCluster()
 	var err error
 	var result *ec2.DescribeSubnetsOutput
@@ -66,7 +66,7 @@ func (ac *awsCloud) findPublicSubnets(vpcID string, filter types.Filter) ([]type
 			filter,
 		}
 
-		result, err = ac.client.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{Filters: filters})
+		result, err = ac.client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{Filters: filters})
 		if err != nil {
 			return nil, errors.Wrap(err, "error describing AWS subnets")
 		}
@@ -79,9 +79,11 @@ func (ac *awsCloud) findPublicSubnets(vpcID string, filter types.Filter) ([]type
 	return result.Subnets, nil
 }
 
-func (ac *awsCloud) getSubnetsSupportingInstanceType(subnets []types.Subnet, instanceType string) ([]types.Subnet, error) {
+func (ac *awsCloud) getSubnetsSupportingInstanceType(ctx context.Context, subnets []types.Subnet,
+	instanceType string,
+) ([]types.Subnet, error) {
 	return filterSubnets(subnets, func(subnet *types.Subnet) (bool, error) {
-		output, err := ac.client.DescribeInstanceTypeOfferings(context.TODO(), &ec2.DescribeInstanceTypeOfferingsInput{
+		output, err := ac.client.DescribeInstanceTypeOfferings(ctx, &ec2.DescribeInstanceTypeOfferingsInput{
 			LocationType: types.LocationTypeAvailabilityZone,
 			Filters: []types.Filter{
 				ec2Filter("location", *subnet.AvailabilityZone),
@@ -96,12 +98,12 @@ func (ac *awsCloud) getSubnetsSupportingInstanceType(subnets []types.Subnet, ins
 	})
 }
 
-func (ac *awsCloud) getTaggedPublicSubnets(vpcID string) ([]types.Subnet, error) {
-	return ac.findPublicSubnets(vpcID, ec2FilterByTag(tagSubmarinerGateway))
+func (ac *awsCloud) getTaggedPublicSubnets(ctx context.Context, vpcID string) ([]types.Subnet, error) {
+	return ac.findPublicSubnets(ctx, vpcID, ec2FilterByTag(tagSubmarinerGateway))
 }
 
-func (ac *awsCloud) tagPublicSubnet(subnetID *string) error {
-	_, err := ac.client.CreateTags(context.TODO(), &ec2.CreateTagsInput{
+func (ac *awsCloud) tagPublicSubnet(ctx context.Context, subnetID *string) error {
+	_, err := ac.client.CreateTags(ctx, &ec2.CreateTagsInput{
 		Resources: []string{*subnetID},
 		Tags: []types.Tag{
 			tagInternalELB,
@@ -112,8 +114,8 @@ func (ac *awsCloud) tagPublicSubnet(subnetID *string) error {
 	return errors.Wrap(err, "error creating AWS tag")
 }
 
-func (ac *awsCloud) untagPublicSubnet(subnetID *string) error {
-	_, err := ac.client.DeleteTags(context.TODO(), &ec2.DeleteTagsInput{
+func (ac *awsCloud) untagPublicSubnet(ctx context.Context, subnetID *string) error {
+	_, err := ac.client.DeleteTags(ctx, &ec2.DeleteTagsInput{
 		Resources: []string{*subnetID},
 		Tags: []types.Tag{
 			tagInternalELB,
@@ -124,8 +126,8 @@ func (ac *awsCloud) untagPublicSubnet(subnetID *string) error {
 	return errors.Wrap(err, "error deleting AWS tag")
 }
 
-func (ac *awsCloud) getSubnetByID(subnetID string) (*types.Subnet, error) {
-	output, err := ac.client.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{
+func (ac *awsCloud) getSubnetByID(ctx context.Context, subnetID string) (*types.Subnet, error) {
+	output, err := ac.client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
 		SubnetIds: []string{subnetID},
 	})
 	if err != nil {

--- a/pkg/aws/validations.go
+++ b/pkg/aws/validations.go
@@ -40,7 +40,7 @@ func determinePermissionError(err error, operation string) error {
 	return errors.Wrapf(err, "error while checking permissions for %s", operation)
 }
 
-func (ac *awsCloud) validateCreateSecGroup(vpcID string) error {
+func (ac *awsCloud) validateCreateSecGroup(ctx context.Context, vpcID string) error {
 	input := &ec2.CreateSecurityGroupInput{
 		DryRun:      ptr.To(true),
 		GroupName:   ptr.To(permissionsTest),
@@ -48,12 +48,12 @@ func (ac *awsCloud) validateCreateSecGroup(vpcID string) error {
 		VpcId:       ptr.To(vpcID),
 	}
 
-	_, err := ac.client.CreateSecurityGroup(context.TODO(), input)
+	_, err := ac.client.CreateSecurityGroup(ctx, input)
 
 	return determinePermissionError(err, "create security group")
 }
 
-func (ac *awsCloud) validateCreateSecGroupRule(vpcID string) error {
+func (ac *awsCloud) validateCreateSecGroupRule(ctx context.Context, vpcID string) error {
 	var workerGroupID *string
 
 	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
@@ -65,7 +65,7 @@ func (ac *awsCloud) validateCreateSecGroupRule(vpcID string) error {
 	} else {
 		var err error
 
-		workerGroupID, err = ac.getSecurityGroupName(vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
+		workerGroupID, err = ac.getSecurityGroupName(ctx, vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
 		if err != nil {
 			return err
 		}
@@ -76,13 +76,13 @@ func (ac *awsCloud) validateCreateSecGroupRule(vpcID string) error {
 		GroupId: workerGroupID,
 	}
 
-	_, err := ac.client.AuthorizeSecurityGroupIngress(context.TODO(), input)
+	_, err := ac.client.AuthorizeSecurityGroupIngress(ctx, input)
 
 	return determinePermissionError(err, "authorize security group ingress")
 }
 
-func (ac *awsCloud) validateCreateTag(subnetID string) error {
-	_, err := ac.client.CreateTags(context.TODO(), &ec2.CreateTagsInput{
+func (ac *awsCloud) validateCreateTag(ctx context.Context, subnetID string) error {
+	_, err := ac.client.CreateTags(ctx, &ec2.CreateTagsInput{
 		DryRun:    ptr.To(true),
 		Resources: []string{subnetID},
 		Tags: []types.Tag{
@@ -93,15 +93,15 @@ func (ac *awsCloud) validateCreateTag(subnetID string) error {
 	return determinePermissionError(err, "create tags on subnets")
 }
 
-func (ac *awsCloud) validateDescribeInstanceTypeOfferings() error {
-	_, err := ac.client.DescribeInstanceTypeOfferings(context.TODO(), &ec2.DescribeInstanceTypeOfferingsInput{
+func (ac *awsCloud) validateDescribeInstanceTypeOfferings(ctx context.Context) error {
+	_, err := ac.client.DescribeInstanceTypeOfferings(ctx, &ec2.DescribeInstanceTypeOfferingsInput{
 		DryRun: ptr.To(true),
 	})
 
 	return determinePermissionError(err, "describe instance type offerings")
 }
 
-func (ac *awsCloud) validateDeleteSecGroup(vpcID string) error {
+func (ac *awsCloud) validateDeleteSecGroup(ctx context.Context, vpcID string) error {
 	var workerGroupID *string
 
 	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
@@ -113,7 +113,7 @@ func (ac *awsCloud) validateDeleteSecGroup(vpcID string) error {
 	} else {
 		var err error
 
-		workerGroupID, err = ac.getSecurityGroupName(vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
+		workerGroupID, err = ac.getSecurityGroupName(ctx, vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
 		if err != nil {
 			return err
 		}
@@ -124,12 +124,12 @@ func (ac *awsCloud) validateDeleteSecGroup(vpcID string) error {
 		GroupId: workerGroupID,
 	}
 
-	_, err := ac.client.DeleteSecurityGroup(context.TODO(), input)
+	_, err := ac.client.DeleteSecurityGroup(ctx, input)
 
 	return determinePermissionError(err, "delete security group")
 }
 
-func (ac *awsCloud) validateDeleteSecGroupRule(vpcID string) error {
+func (ac *awsCloud) validateDeleteSecGroupRule(ctx context.Context, vpcID string) error {
 	var workerGroupID *string
 
 	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
@@ -141,7 +141,7 @@ func (ac *awsCloud) validateDeleteSecGroupRule(vpcID string) error {
 	} else {
 		var err error
 
-		workerGroupID, err = ac.getSecurityGroupName(vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
+		workerGroupID, err = ac.getSecurityGroupName(ctx, vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
 		if err != nil {
 			return err
 		}
@@ -152,13 +152,13 @@ func (ac *awsCloud) validateDeleteSecGroupRule(vpcID string) error {
 		GroupId: workerGroupID,
 	}
 
-	_, err := ac.client.RevokeSecurityGroupIngress(context.TODO(), input)
+	_, err := ac.client.RevokeSecurityGroupIngress(ctx, input)
 
 	return determinePermissionError(err, "revoke security group ingress")
 }
 
-func (ac *awsCloud) validateRemoveTag(subnetID *string) error {
-	_, err := ac.client.DeleteTags(context.TODO(), &ec2.DeleteTagsInput{
+func (ac *awsCloud) validateRemoveTag(ctx context.Context, subnetID *string) error {
+	_, err := ac.client.DeleteTags(ctx, &ec2.DeleteTagsInput{
 		DryRun:    ptr.To(true),
 		Resources: []string{*subnetID},
 		Tags: []types.Tag{

--- a/pkg/aws/vpcs.go
+++ b/pkg/aws/vpcs.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (ac *awsCloud) getVpcID() (string, error) {
+func (ac *awsCloud) getVpcID(ctx context.Context) (string, error) {
 	var err error
 	var result *ec2.DescribeVpcsOutput
 
@@ -48,7 +48,7 @@ func (ac *awsCloud) getVpcID() (string, error) {
 			ownedFilters[i],
 		}
 
-		result, err = ac.client.DescribeVpcs(context.TODO(), &ec2.DescribeVpcsInput{Filters: filters})
+		result, err = ac.client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{Filters: filters})
 		if err != nil {
 			return "", errors.Wrap(err, "error describing AWS VPCs")
 		}

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -19,12 +19,16 @@ limitations under the License.
 package azure
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	reporterInterface "github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/cloud-prepare/pkg/api"
 )
+
+var operationTimeout = 300 * time.Second
 
 type azureCloud struct {
 	CloudInfo
@@ -37,7 +41,7 @@ func NewCloud(info *CloudInfo) api.Cloud {
 	}
 }
 
-func (az *azureCloud) OpenPorts(ports []api.PortSpec, reporter reporterInterface.Interface) error {
+func (az *azureCloud) OpenPorts(ctx context.Context, ports []api.PortSpec, reporter reporterInterface.Interface) error {
 	reporter.Start("Opening internal ports for intra-cluster communications on Azure")
 
 	nsgClient, err := az.getNsgClient()
@@ -45,7 +49,10 @@ func (az *azureCloud) OpenPorts(ports []api.PortSpec, reporter reporterInterface
 		return reporter.Error(err, "Failed to get network security groups client")
 	}
 
-	if err := az.openInternalPorts(az.InfraID, ports, nsgClient); err != nil {
+	ctx, cancel := context.WithTimeout(ctx, operationTimeout)
+	defer cancel()
+
+	if err := az.openInternalPorts(ctx, az.InfraID, ports, nsgClient); err != nil {
 		return reporter.Error(err, "Failed to open internal ports")
 	}
 
@@ -54,7 +61,7 @@ func (az *azureCloud) OpenPorts(ports []api.PortSpec, reporter reporterInterface
 	return nil
 }
 
-func (az *azureCloud) ClosePorts(reporter reporterInterface.Interface) error {
+func (az *azureCloud) ClosePorts(ctx context.Context, reporter reporterInterface.Interface) error {
 	reporter.Start("Revoking intra-cluster communication permissions")
 
 	nsgClient, err := az.getNsgClient()
@@ -62,7 +69,10 @@ func (az *azureCloud) ClosePorts(reporter reporterInterface.Interface) error {
 		return reporter.Error(err, "Failed to get network security groups client")
 	}
 
-	if err := az.removeInternalFirewallRules(az.InfraID, nsgClient); err != nil {
+	ctx, cancel := context.WithTimeout(ctx, operationTimeout)
+	defer cancel()
+
+	if err := az.removeInternalFirewallRules(ctx, az.InfraID, nsgClient); err != nil {
 		return reporter.Error(err, "Failed to revoke intra-cluster communication permissions")
 	}
 

--- a/pkg/azure/cloud_info.go
+++ b/pkg/azure/cloud_info.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
@@ -73,11 +72,10 @@ func (c *CloudInfo) getResourceSKUClient() (*armcompute.ResourceSKUsClient, erro
 	return armcompute.NewResourceSKUsClient(c.SubscriptionID, c.TokenCredential, nil)
 }
 
-func (c *CloudInfo) openInternalPorts(infraID string, ports []api.PortSpec, nsgClient *armnetwork.SecurityGroupsClient) error {
+func (c *CloudInfo) openInternalPorts(ctx context.Context, infraID string, ports []api.PortSpec,
+	nsgClient *armnetwork.SecurityGroupsClient,
+) error {
 	groupName := infraID + internalSecurityGroupSuffix
-
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	nwSecurityGroup, err := nsgClient.Get(ctx, c.BaseGroupName, groupName, nil)
 	if err != nil {
@@ -113,11 +111,8 @@ func (c *CloudInfo) openInternalPorts(infraID string, ports []api.PortSpec, nsgC
 	return errors.Wrapf(err, "error updating  security group %q with submariner rules", groupName)
 }
 
-func (c *CloudInfo) removeInternalFirewallRules(infraID string, nsgClient *armnetwork.SecurityGroupsClient) error {
+func (c *CloudInfo) removeInternalFirewallRules(ctx context.Context, infraID string, nsgClient *armnetwork.SecurityGroupsClient) error {
 	groupName := infraID + internalSecurityGroupSuffix
-
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	nwSecurityGroup, err := nsgClient.Get(ctx, c.BaseGroupName, groupName, nil)
 	if err != nil {
@@ -178,10 +173,9 @@ func (c *CloudInfo) createSecurityRule(securityRulePrfix string, protocol armnet
 	}
 }
 
-func (c *CloudInfo) createGWSecurityGroup(groupName string, ports []api.PortSpec, nsgClient *armnetwork.SecurityGroupsClient) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
-
+func (c *CloudInfo) createGWSecurityGroup(ctx context.Context, groupName string, ports []api.PortSpec,
+	nsgClient *armnetwork.SecurityGroupsClient,
+) error {
 	isFound := c.checkIfSecurityGroupPresent(ctx, groupName, nsgClient)
 	if isFound {
 		return nil
@@ -216,12 +210,9 @@ func (c *CloudInfo) createGWSecurityGroup(groupName string, ports []api.PortSpec
 	return errors.Wrapf(err, "Error creating  security group %v ", groupName)
 }
 
-func (c *CloudInfo) prepareGWInterface(nodeName, groupName string, nsgClient *armnetwork.SecurityGroupsClient,
+func (c *CloudInfo) prepareGWInterface(ctx context.Context, nodeName, groupName string, nsgClient *armnetwork.SecurityGroupsClient,
 	nwClient *armnetwork.InterfacesClient, pubIPClient *armnetwork.PublicIPAddressesClient,
 ) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
-
 	nwSecurityGroup, err := nsgClient.Get(ctx, c.BaseGroupName, groupName, nil)
 	if err != nil {
 		return errors.Wrapf(err, "error getting the submariner gateway security group %q", groupName)
@@ -269,13 +260,10 @@ func (c *CloudInfo) prepareGWInterface(nodeName, groupName string, nsgClient *ar
 	return errors.Wrapf(err, "updating interface %q failed", *nwInterface.Name)
 }
 
-func (c *CloudInfo) cleanupGWInterface(infraID string, nsgClient *armnetwork.SecurityGroupsClient,
+func (c *CloudInfo) cleanupGWInterface(ctx context.Context, infraID string, nsgClient *armnetwork.SecurityGroupsClient,
 	nwClient *armnetwork.InterfacesClient,
 ) error {
 	groupName := infraID + externalSecurityGroupSuffix
-
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	isFound := c.checkIfSecurityGroupPresent(ctx, groupName, nsgClient)
 

--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -90,7 +90,7 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 		return status.Error(err, "error getting the gateway machinesets")
 	}
 
-	gwNodes, err := d.azure.K8sClient.ListGatewayNodes()
+	gwNodes, err := d.azure.K8sClient.ListGatewayNodes(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error getting the gateway node")
 	}
@@ -351,7 +351,7 @@ func (d *ocpGatewayDeployer) deleteGateway(ctx context.Context, status reporter.
 	}
 
 	// Cleanup nodes that are not dedicated gateway nodes.
-	gwNodesList, err := d.K8sClient.ListGatewayNodes()
+	gwNodesList, err := d.K8sClient.ListGatewayNodes(ctx)
 	if err != nil {
 		return status.Error(err, "error listing the Submariner gateway nodes")
 	}
@@ -359,7 +359,7 @@ func (d *ocpGatewayDeployer) deleteGateway(ctx context.Context, status reporter.
 	gwNodes := ocp.RemoveDuplicates(machineSetList, gwNodesList.Items)
 
 	for i := range gwNodes {
-		err = d.K8sClient.RemoveGWLabelFromWorkerNode(&gwNodes[i])
+		err = d.K8sClient.RemoveGWLabelFromWorkerNode(ctx, &gwNodes[i])
 		if err != nil {
 			return status.Error(err, "failed to cleanup node %q", gwNodes[i].Name)
 		}

--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"strconv"
 	"text/template"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
@@ -69,7 +68,7 @@ func NewOcpGatewayDeployer(info *CloudInfo, cloud api.Cloud, msDeployer ocp.Mach
 	}, nil
 }
 
-func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeployInput, status reporter.Interface) error {
 	if input.Gateways == 0 {
 		return nil
 	}
@@ -82,6 +81,9 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 	}
 
 	groupName := d.InfraID + externalSecurityGroupSuffix
+
+	ctx, cancel := context.WithTimeout(ctx, operationTimeout)
+	defer cancel()
 
 	machineSets, err := d.msDeployer.List()
 	if err != nil {
@@ -98,14 +100,14 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 	gatewayNodesToDeploy := input.Gateways - len(machineSets) - len(taggedExistingNodes)
 
 	if len(machineSets) != 0 || gatewayNodesToDeploy != 0 {
-		if err := d.createGWSecurityGroup(groupName, input.PublicPorts, nsgClient); err != nil {
+		if err := d.createGWSecurityGroup(ctx, groupName, input.PublicPorts, nsgClient); err != nil {
 			return status.Error(err, "creating gateway security group failed")
 		}
 	}
 
 	// Open the g/w ports and assign public-ip if not already done for manually tagged nodes if any
 	for i := range gwNodeItems {
-		if err = d.prepareGWInterface(gwNodeItems[i].GetName(), groupName, nsgClient, nwClient, pubIPClient); err != nil {
+		if err = d.prepareGWInterface(ctx, gwNodeItems[i].GetName(), groupName, nsgClient, nwClient, pubIPClient); err != nil {
 			return status.Error(err, "failed to open the Submariner gateway port for already existing nodes")
 		}
 	}
@@ -128,7 +130,7 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 		return errors.Wrap(imageErr, "error retrieving worker node image")
 	}
 
-	err = d.deployDedicatedGWNode(machineSets, gatewayNodesToDeploy, input.AirGapped, image, status)
+	err = d.deployDedicatedGWNode(ctx, machineSets, gatewayNodesToDeploy, input.AirGapped, image, status)
 	if err != nil {
 		status.Success("Deployed gateway node")
 	}
@@ -136,10 +138,10 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 	return err
 }
 
-func (d *ocpGatewayDeployer) deployDedicatedGWNode(gwNodes []unstructured.Unstructured, gatewayNodesToDeploy int,
-	airGapped bool, image string, status reporter.Interface,
+func (d *ocpGatewayDeployer) deployDedicatedGWNode(ctx context.Context, gwNodes []unstructured.Unstructured,
+	gatewayNodesToDeploy int, airGapped bool, image string, status reporter.Interface,
 ) error {
-	az, err := d.getAvailabilityZones(gwNodes)
+	az, err := d.getAvailabilityZones(ctx, gwNodes)
 	if err != nil {
 		return status.Error(err, "error getting the availability zones for region %q", d.Region)
 	}
@@ -244,7 +246,8 @@ func MachineName(region string) string {
 	return submarinerGatewayGW + region + "-" + string(uuid.NewUUID())[0:6]
 }
 
-func (d *ocpGatewayDeployer) getAvailabilityZones(gwNodes []unstructured.Unstructured) (set.Set[string], error) {
+func (d *ocpGatewayDeployer) getAvailabilityZones(ctx context.Context, gwNodes []unstructured.Unstructured,
+) (set.Set[string], error) {
 	zonesWithSubmarinerGW := set.New[string]()
 
 	for i := range gwNodes {
@@ -255,9 +258,6 @@ func (d *ocpGatewayDeployer) getAvailabilityZones(gwNodes []unstructured.Unstruc
 
 		zonesWithSubmarinerGW.Insert(zone)
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	resourceSKUClient, err := d.getResourceSKUClient()
 	if err != nil {
@@ -290,7 +290,7 @@ func (d *ocpGatewayDeployer) getAvailabilityZones(gwNodes []unstructured.Unstruc
 	return eligibleZonesForSubmarinerGW, nil
 }
 
-func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interface) error {
 	status.Start("Removing gateway node")
 
 	nsgClient, err := d.getNsgClient()
@@ -303,11 +303,14 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 		return status.Error(err, "Failed to get network interfaces client")
 	}
 
-	if err := d.cleanupGWInterface(d.InfraID, nsgClient, nwClient); err != nil {
+	ctx, cancel := context.WithTimeout(ctx, operationTimeout)
+	defer cancel()
+
+	if err := d.cleanupGWInterface(ctx, d.InfraID, nsgClient, nwClient); err != nil {
 		return status.Error(err, "deleting gateway security group failed")
 	}
 
-	err = d.deleteGateway(status)
+	err = d.deleteGateway(ctx, status)
 	if err != nil {
 		return err
 	}
@@ -317,7 +320,7 @@ func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
 	return nil
 }
 
-func (d *ocpGatewayDeployer) deleteGateway(status reporter.Interface) error {
+func (d *ocpGatewayDeployer) deleteGateway(ctx context.Context, status reporter.Interface) error {
 	machineSetList, err := d.msDeployer.List()
 	if err != nil {
 		return status.Error(err, "error listing the Submariner gateway nodes")
@@ -327,9 +330,6 @@ func (d *ocpGatewayDeployer) deleteGateway(status reporter.Interface) error {
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get network public IP addresses client")
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	for i := range machineSetList {
 		status.Start("Deleting the gateway instance %q", machineSetList[i].GetName())

--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -85,7 +85,7 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 	ctx, cancel := context.WithTimeout(ctx, operationTimeout)
 	defer cancel()
 
-	machineSets, err := d.msDeployer.List()
+	machineSets, err := d.msDeployer.List(ctx)
 	if err != nil {
 		return status.Error(err, "error getting the gateway machinesets")
 	}
@@ -125,7 +125,7 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 		return nil
 	}
 
-	image, imageErr := d.msDeployer.GetWorkerNodeImage(nil, d.InfraID)
+	image, imageErr := d.msDeployer.GetWorkerNodeImage(ctx, nil, d.InfraID)
 	if imageErr != nil {
 		return errors.Wrap(imageErr, "error retrieving worker node image")
 	}
@@ -149,7 +149,7 @@ func (d *ocpGatewayDeployer) deployDedicatedGWNode(ctx context.Context, gwNodes 
 	for _, zone := range az.UnsortedList() {
 		status.Start("Deploying dedicated gateway node")
 
-		err := d.deployGateway(zone, image, airGapped)
+		err := d.deployGateway(ctx, zone, image, airGapped)
 		if err != nil {
 			return status.Error(err, "error deploying gateway for zone %q", zone)
 		}
@@ -223,13 +223,13 @@ func (d *ocpGatewayDeployer) initMachineSet(name, zone, image string, airGapped 
 	return machineSet, nil
 }
 
-func (d *ocpGatewayDeployer) deployGateway(zone, image string, airGapped bool) error {
+func (d *ocpGatewayDeployer) deployGateway(ctx context.Context, zone, image string, airGapped bool) error {
 	machineSet, err := d.initMachineSet(MachineName(d.azure.Region), zone, image, airGapped)
 	if err != nil {
 		return err
 	}
 
-	return errors.Wrapf(d.msDeployer.Deploy(machineSet), "error deploying machine set %q", machineSet.GetName())
+	return errors.Wrapf(d.msDeployer.Deploy(ctx, machineSet), "error deploying machine set %q", machineSet.GetName())
 }
 
 // MachineName generates a machine name for the gateway.
@@ -321,7 +321,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 }
 
 func (d *ocpGatewayDeployer) deleteGateway(ctx context.Context, status reporter.Interface) error {
-	machineSetList, err := d.msDeployer.List()
+	machineSetList, err := d.msDeployer.List(ctx)
 	if err != nil {
 		return status.Error(err, "error listing the Submariner gateway nodes")
 	}
@@ -334,7 +334,7 @@ func (d *ocpGatewayDeployer) deleteGateway(ctx context.Context, status reporter.
 	for i := range machineSetList {
 		status.Start("Deleting the gateway instance %q", machineSetList[i].GetName())
 
-		err = d.msDeployer.DeleteByName(machineSetList[i].GetName(), machineSetList[i].GetNamespace())
+		err = d.msDeployer.DeleteByName(ctx, machineSetList[i].GetName(), machineSetList[i].GetNamespace())
 		if err != nil {
 			return status.Error(err, "error deleting the gateway instance from node: %q",
 				machineSetList[i].GetName())

--- a/pkg/azure/ocpgwdeployer_internal_test.go
+++ b/pkg/azure/ocpgwdeployer_internal_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package azure
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
@@ -62,14 +64,15 @@ var _ = Describe("OCP Gateway Deployer", func() {
 
 	Describe("deployGateway", func() {
 		JustBeforeEach(func() {
-			msDeployer.EXPECT().Deploy(mock.Anything).RunAndReturn(func(ms *unstructured.Unstructured) error {
-				machineSet = ms
-				return nil
-			}).Maybe()
+			msDeployer.EXPECT().Deploy(mock.Anything, mock.Anything).RunAndReturn(
+				func(_ context.Context, ms *unstructured.Unstructured) error {
+					machineSet = ms
+					return nil
+				}).Maybe()
 		})
 
 		It("should deploy the correct MachineSet", func() {
-			Expect(gwDeployer.deployGateway(zone, image, false)).To(Succeed())
+			Expect(gwDeployer.deployGateway(context.TODO(), zone, image, false)).To(Succeed())
 
 			Expect(machineSet).ToNot(BeNil())
 			Expect(machineSet.GetLabels()).To(HaveKeyWithValue("machine.openshift.io/cluster-api-cluster", infraID))
@@ -83,7 +86,7 @@ var _ = Describe("OCP Gateway Deployer", func() {
 			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "publicIP")).To(BeTrue())
 
 			machineSet = nil
-			Expect(gwDeployer.deployGateway(zone, image, true)).To(Succeed())
+			Expect(gwDeployer.deployGateway(context.TODO(), zone, image, true)).To(Succeed())
 
 			Expect(machineSet).ToNot(BeNil())
 			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "publicIP")).To(BeFalse())

--- a/pkg/gcp/client/client.go
+++ b/pkg/gcp/client/client.go
@@ -35,17 +35,17 @@ import (
 
 // Interface wraps an actual GCP library client to allow for easier testing.
 type Interface interface {
-	InsertFirewallRule(projectID string, rule *compute.Firewall) error
-	GetFirewallRule(projectID, name string) (*compute.Firewall, error)
-	DeleteFirewallRule(projectID, name string) error
-	UpdateFirewallRule(projectID, name string, rule *compute.Firewall) error
-	GetInstance(zone string, instance string) (*compute.Instance, error)
-	ListInstances(zone string) (*compute.InstanceList, error)
-	ListZones() (*compute.ZoneList, error)
-	InstanceHasPublicIP(instance *compute.Instance) (bool, error)
-	UpdateInstanceNetworkTags(project, zone, instance string, tags *compute.Tags) error
-	ConfigurePublicIPOnInstance(instance *compute.Instance) error
-	DeletePublicIPOnInstance(instance *compute.Instance) error
+	InsertFirewallRule(ctx context.Context, projectID string, rule *compute.Firewall) error
+	GetFirewallRule(ctx context.Context, projectID, name string) (*compute.Firewall, error)
+	DeleteFirewallRule(ctx context.Context, projectID, name string) error
+	UpdateFirewallRule(ctx context.Context, projectID, name string, rule *compute.Firewall) error
+	GetInstance(ctx context.Context, zone string, instance string) (*compute.Instance, error)
+	ListInstances(ctx context.Context, zone string) (*compute.InstanceList, error)
+	ListZones(ctx context.Context) (*compute.ZoneList, error)
+	InstanceHasPublicIP(ctx context.Context, instance *compute.Instance) (bool, error)
+	UpdateInstanceNetworkTags(ctx context.Context, project, zone, instance string, tags *compute.Tags) error
+	ConfigurePublicIPOnInstance(ctx context.Context, instance *compute.Instance) error
+	DeletePublicIPOnInstance(ctx context.Context, instance *compute.Instance) error
 }
 
 type gcpClient struct {
@@ -53,28 +53,26 @@ type gcpClient struct {
 	computeClient *compute.Service
 }
 
-func (g *gcpClient) InsertFirewallRule(projectID string, rule *compute.Firewall) error {
-	_, err := g.computeClient.Firewalls.Insert(projectID, rule).Context(context.TODO()).Do()
+func (g *gcpClient) InsertFirewallRule(ctx context.Context, projectID string, rule *compute.Firewall) error {
+	_, err := g.computeClient.Firewalls.Insert(projectID, rule).Context(ctx).Do()
 	return err
 }
 
-func (g *gcpClient) GetFirewallRule(projectID, name string) (*compute.Firewall, error) {
-	return g.computeClient.Firewalls.Get(projectID, name).Context(context.TODO()).Do()
+func (g *gcpClient) GetFirewallRule(ctx context.Context, projectID, name string) (*compute.Firewall, error) {
+	return g.computeClient.Firewalls.Get(projectID, name).Context(ctx).Do()
 }
 
-func (g *gcpClient) DeleteFirewallRule(projectID, name string) error {
-	_, err := g.computeClient.Firewalls.Delete(projectID, name).Context(context.TODO()).Do()
+func (g *gcpClient) DeleteFirewallRule(ctx context.Context, projectID, name string) error {
+	_, err := g.computeClient.Firewalls.Delete(projectID, name).Context(ctx).Do()
 	return err
 }
 
-func (g *gcpClient) UpdateFirewallRule(projectID, name string, rule *compute.Firewall) error {
-	_, err := g.computeClient.Firewalls.Update(projectID, name, rule).Context(context.TODO()).Do()
+func (g *gcpClient) UpdateFirewallRule(ctx context.Context, projectID, name string, rule *compute.Firewall) error {
+	_, err := g.computeClient.Firewalls.Update(projectID, name, rule).Context(ctx).Do()
 	return err
 }
 
-func NewClient(projectID string, options []option.ClientOption) (Interface, error) {
-	ctx := context.TODO()
-
+func NewClient(ctx context.Context, projectID string, options []option.ClientOption) (Interface, error) {
 	computeClient, err := compute.NewService(ctx, options...)
 	if err != nil {
 		return nil, err
@@ -95,19 +93,19 @@ func IsGCPNotFoundError(err error) bool {
 	return false
 }
 
-func (g *gcpClient) GetInstance(zone, instance string) (*compute.Instance, error) {
-	return g.computeClient.Instances.Get(g.projectID, zone, instance).Context(context.TODO()).Do()
+func (g *gcpClient) GetInstance(ctx context.Context, zone, instance string) (*compute.Instance, error) {
+	return g.computeClient.Instances.Get(g.projectID, zone, instance).Context(ctx).Do()
 }
 
-func (g *gcpClient) ListInstances(zone string) (*compute.InstanceList, error) {
-	return g.computeClient.Instances.List(g.projectID, zone).Context(context.TODO()).Do()
+func (g *gcpClient) ListInstances(ctx context.Context, zone string) (*compute.InstanceList, error) {
+	return g.computeClient.Instances.List(g.projectID, zone).Context(ctx).Do()
 }
 
-func (g *gcpClient) ListZones() (*compute.ZoneList, error) {
-	return g.computeClient.Zones.List(g.projectID).Context(context.TODO()).Do()
+func (g *gcpClient) ListZones(ctx context.Context) (*compute.ZoneList, error) {
+	return g.computeClient.Zones.List(g.projectID).Context(ctx).Do()
 }
 
-func (g *gcpClient) InstanceHasPublicIP(instance *compute.Instance) (bool, error) {
+func (g *gcpClient) InstanceHasPublicIP(ctx context.Context, instance *compute.Instance) (bool, error) {
 	networkInterface, err := getNetworkInterface(instance)
 	if err != nil {
 		return false, err
@@ -116,13 +114,13 @@ func (g *gcpClient) InstanceHasPublicIP(instance *compute.Instance) (bool, error
 	return len(networkInterface.AccessConfigs) > 0, nil
 }
 
-func (g *gcpClient) UpdateInstanceNetworkTags(project, zone, instance string, tags *compute.Tags) error {
-	_, err := g.computeClient.Instances.SetTags(project, zone, instance, tags).Context(context.TODO()).Do()
+func (g *gcpClient) UpdateInstanceNetworkTags(ctx context.Context, project, zone, instance string, tags *compute.Tags) error {
+	_, err := g.computeClient.Instances.SetTags(project, zone, instance, tags).Context(ctx).Do()
 
 	return err
 }
 
-func (g *gcpClient) ConfigurePublicIPOnInstance(instance *compute.Instance) error {
+func (g *gcpClient) ConfigurePublicIPOnInstance(ctx context.Context, instance *compute.Instance) error {
 	networkInterface, err := getNetworkInterface(instance)
 	if err != nil {
 		return err
@@ -138,12 +136,12 @@ func (g *gcpClient) ConfigurePublicIPOnInstance(instance *compute.Instance) erro
 
 	_, err = g.computeClient.Instances.AddAccessConfig(g.projectID, zone, instance.Name,
 		networkInterface.Name, &compute.AccessConfig{}).
-		Context(context.TODO()).Do()
+		Context(ctx).Do()
 
 	return err
 }
 
-func (g *gcpClient) DeletePublicIPOnInstance(instance *compute.Instance) error {
+func (g *gcpClient) DeletePublicIPOnInstance(ctx context.Context, instance *compute.Instance) error {
 	networkInterface, err := getNetworkInterface(instance)
 	if err != nil {
 		return err
@@ -153,7 +151,7 @@ func (g *gcpClient) DeletePublicIPOnInstance(instance *compute.Instance) error {
 	zone := instance.Zone[strings.LastIndex(instance.Zone, "/")+1:]
 	_, err = g.computeClient.Instances.DeleteAccessConfig(
 		g.projectID, zone, instance.Name, "External NAT", networkInterface.Name).
-		Context(context.TODO()).Do()
+		Context(ctx).Do()
 
 	return err
 }

--- a/pkg/gcp/client/fake/client.go
+++ b/pkg/gcp/client/fake/client.go
@@ -22,6 +22,8 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 	"google.golang.org/api/compute/v1"
 )
@@ -54,16 +56,16 @@ func (_m *MockInterface) EXPECT() *MockInterface_Expecter {
 }
 
 // ConfigurePublicIPOnInstance provides a mock function for the type MockInterface
-func (_mock *MockInterface) ConfigurePublicIPOnInstance(instance *compute.Instance) error {
-	ret := _mock.Called(instance)
+func (_mock *MockInterface) ConfigurePublicIPOnInstance(ctx context.Context, instance *compute.Instance) error {
+	ret := _mock.Called(ctx, instance)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ConfigurePublicIPOnInstance")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*compute.Instance) error); ok {
-		r0 = returnFunc(instance)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *compute.Instance) error); ok {
+		r0 = returnFunc(ctx, instance)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -76,14 +78,15 @@ type MockInterface_ConfigurePublicIPOnInstance_Call struct {
 }
 
 // ConfigurePublicIPOnInstance is a helper method to define mock.On call
+//   - ctx
 //   - instance
-func (_e *MockInterface_Expecter) ConfigurePublicIPOnInstance(instance interface{}) *MockInterface_ConfigurePublicIPOnInstance_Call {
-	return &MockInterface_ConfigurePublicIPOnInstance_Call{Call: _e.mock.On("ConfigurePublicIPOnInstance", instance)}
+func (_e *MockInterface_Expecter) ConfigurePublicIPOnInstance(ctx interface{}, instance interface{}) *MockInterface_ConfigurePublicIPOnInstance_Call {
+	return &MockInterface_ConfigurePublicIPOnInstance_Call{Call: _e.mock.On("ConfigurePublicIPOnInstance", ctx, instance)}
 }
 
-func (_c *MockInterface_ConfigurePublicIPOnInstance_Call) Run(run func(instance *compute.Instance)) *MockInterface_ConfigurePublicIPOnInstance_Call {
+func (_c *MockInterface_ConfigurePublicIPOnInstance_Call) Run(run func(ctx context.Context, instance *compute.Instance)) *MockInterface_ConfigurePublicIPOnInstance_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*compute.Instance))
+		run(args[0].(context.Context), args[1].(*compute.Instance))
 	})
 	return _c
 }
@@ -93,22 +96,22 @@ func (_c *MockInterface_ConfigurePublicIPOnInstance_Call) Return(err error) *Moc
 	return _c
 }
 
-func (_c *MockInterface_ConfigurePublicIPOnInstance_Call) RunAndReturn(run func(instance *compute.Instance) error) *MockInterface_ConfigurePublicIPOnInstance_Call {
+func (_c *MockInterface_ConfigurePublicIPOnInstance_Call) RunAndReturn(run func(ctx context.Context, instance *compute.Instance) error) *MockInterface_ConfigurePublicIPOnInstance_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteFirewallRule provides a mock function for the type MockInterface
-func (_mock *MockInterface) DeleteFirewallRule(projectID string, name string) error {
-	ret := _mock.Called(projectID, name)
+func (_mock *MockInterface) DeleteFirewallRule(ctx context.Context, projectID string, name string) error {
+	ret := _mock.Called(ctx, projectID, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteFirewallRule")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(projectID, name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, projectID, name)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -121,15 +124,16 @@ type MockInterface_DeleteFirewallRule_Call struct {
 }
 
 // DeleteFirewallRule is a helper method to define mock.On call
+//   - ctx
 //   - projectID
 //   - name
-func (_e *MockInterface_Expecter) DeleteFirewallRule(projectID interface{}, name interface{}) *MockInterface_DeleteFirewallRule_Call {
-	return &MockInterface_DeleteFirewallRule_Call{Call: _e.mock.On("DeleteFirewallRule", projectID, name)}
+func (_e *MockInterface_Expecter) DeleteFirewallRule(ctx interface{}, projectID interface{}, name interface{}) *MockInterface_DeleteFirewallRule_Call {
+	return &MockInterface_DeleteFirewallRule_Call{Call: _e.mock.On("DeleteFirewallRule", ctx, projectID, name)}
 }
 
-func (_c *MockInterface_DeleteFirewallRule_Call) Run(run func(projectID string, name string)) *MockInterface_DeleteFirewallRule_Call {
+func (_c *MockInterface_DeleteFirewallRule_Call) Run(run func(ctx context.Context, projectID string, name string)) *MockInterface_DeleteFirewallRule_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -139,22 +143,22 @@ func (_c *MockInterface_DeleteFirewallRule_Call) Return(err error) *MockInterfac
 	return _c
 }
 
-func (_c *MockInterface_DeleteFirewallRule_Call) RunAndReturn(run func(projectID string, name string) error) *MockInterface_DeleteFirewallRule_Call {
+func (_c *MockInterface_DeleteFirewallRule_Call) RunAndReturn(run func(ctx context.Context, projectID string, name string) error) *MockInterface_DeleteFirewallRule_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeletePublicIPOnInstance provides a mock function for the type MockInterface
-func (_mock *MockInterface) DeletePublicIPOnInstance(instance *compute.Instance) error {
-	ret := _mock.Called(instance)
+func (_mock *MockInterface) DeletePublicIPOnInstance(ctx context.Context, instance *compute.Instance) error {
+	ret := _mock.Called(ctx, instance)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeletePublicIPOnInstance")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*compute.Instance) error); ok {
-		r0 = returnFunc(instance)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *compute.Instance) error); ok {
+		r0 = returnFunc(ctx, instance)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -167,14 +171,15 @@ type MockInterface_DeletePublicIPOnInstance_Call struct {
 }
 
 // DeletePublicIPOnInstance is a helper method to define mock.On call
+//   - ctx
 //   - instance
-func (_e *MockInterface_Expecter) DeletePublicIPOnInstance(instance interface{}) *MockInterface_DeletePublicIPOnInstance_Call {
-	return &MockInterface_DeletePublicIPOnInstance_Call{Call: _e.mock.On("DeletePublicIPOnInstance", instance)}
+func (_e *MockInterface_Expecter) DeletePublicIPOnInstance(ctx interface{}, instance interface{}) *MockInterface_DeletePublicIPOnInstance_Call {
+	return &MockInterface_DeletePublicIPOnInstance_Call{Call: _e.mock.On("DeletePublicIPOnInstance", ctx, instance)}
 }
 
-func (_c *MockInterface_DeletePublicIPOnInstance_Call) Run(run func(instance *compute.Instance)) *MockInterface_DeletePublicIPOnInstance_Call {
+func (_c *MockInterface_DeletePublicIPOnInstance_Call) Run(run func(ctx context.Context, instance *compute.Instance)) *MockInterface_DeletePublicIPOnInstance_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*compute.Instance))
+		run(args[0].(context.Context), args[1].(*compute.Instance))
 	})
 	return _c
 }
@@ -184,14 +189,14 @@ func (_c *MockInterface_DeletePublicIPOnInstance_Call) Return(err error) *MockIn
 	return _c
 }
 
-func (_c *MockInterface_DeletePublicIPOnInstance_Call) RunAndReturn(run func(instance *compute.Instance) error) *MockInterface_DeletePublicIPOnInstance_Call {
+func (_c *MockInterface_DeletePublicIPOnInstance_Call) RunAndReturn(run func(ctx context.Context, instance *compute.Instance) error) *MockInterface_DeletePublicIPOnInstance_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetFirewallRule provides a mock function for the type MockInterface
-func (_mock *MockInterface) GetFirewallRule(projectID string, name string) (*compute.Firewall, error) {
-	ret := _mock.Called(projectID, name)
+func (_mock *MockInterface) GetFirewallRule(ctx context.Context, projectID string, name string) (*compute.Firewall, error) {
+	ret := _mock.Called(ctx, projectID, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetFirewallRule")
@@ -199,18 +204,18 @@ func (_mock *MockInterface) GetFirewallRule(projectID string, name string) (*com
 
 	var r0 *compute.Firewall
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (*compute.Firewall, error)); ok {
-		return returnFunc(projectID, name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*compute.Firewall, error)); ok {
+		return returnFunc(ctx, projectID, name)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) *compute.Firewall); ok {
-		r0 = returnFunc(projectID, name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *compute.Firewall); ok {
+		r0 = returnFunc(ctx, projectID, name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*compute.Firewall)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(projectID, name)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, projectID, name)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -223,15 +228,16 @@ type MockInterface_GetFirewallRule_Call struct {
 }
 
 // GetFirewallRule is a helper method to define mock.On call
+//   - ctx
 //   - projectID
 //   - name
-func (_e *MockInterface_Expecter) GetFirewallRule(projectID interface{}, name interface{}) *MockInterface_GetFirewallRule_Call {
-	return &MockInterface_GetFirewallRule_Call{Call: _e.mock.On("GetFirewallRule", projectID, name)}
+func (_e *MockInterface_Expecter) GetFirewallRule(ctx interface{}, projectID interface{}, name interface{}) *MockInterface_GetFirewallRule_Call {
+	return &MockInterface_GetFirewallRule_Call{Call: _e.mock.On("GetFirewallRule", ctx, projectID, name)}
 }
 
-func (_c *MockInterface_GetFirewallRule_Call) Run(run func(projectID string, name string)) *MockInterface_GetFirewallRule_Call {
+func (_c *MockInterface_GetFirewallRule_Call) Run(run func(ctx context.Context, projectID string, name string)) *MockInterface_GetFirewallRule_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -241,14 +247,14 @@ func (_c *MockInterface_GetFirewallRule_Call) Return(firewall *compute.Firewall,
 	return _c
 }
 
-func (_c *MockInterface_GetFirewallRule_Call) RunAndReturn(run func(projectID string, name string) (*compute.Firewall, error)) *MockInterface_GetFirewallRule_Call {
+func (_c *MockInterface_GetFirewallRule_Call) RunAndReturn(run func(ctx context.Context, projectID string, name string) (*compute.Firewall, error)) *MockInterface_GetFirewallRule_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetInstance provides a mock function for the type MockInterface
-func (_mock *MockInterface) GetInstance(zone string, instance string) (*compute.Instance, error) {
-	ret := _mock.Called(zone, instance)
+func (_mock *MockInterface) GetInstance(ctx context.Context, zone string, instance string) (*compute.Instance, error) {
+	ret := _mock.Called(ctx, zone, instance)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetInstance")
@@ -256,18 +262,18 @@ func (_mock *MockInterface) GetInstance(zone string, instance string) (*compute.
 
 	var r0 *compute.Instance
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (*compute.Instance, error)); ok {
-		return returnFunc(zone, instance)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*compute.Instance, error)); ok {
+		return returnFunc(ctx, zone, instance)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) *compute.Instance); ok {
-		r0 = returnFunc(zone, instance)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *compute.Instance); ok {
+		r0 = returnFunc(ctx, zone, instance)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*compute.Instance)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(zone, instance)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, zone, instance)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -280,15 +286,16 @@ type MockInterface_GetInstance_Call struct {
 }
 
 // GetInstance is a helper method to define mock.On call
+//   - ctx
 //   - zone
 //   - instance
-func (_e *MockInterface_Expecter) GetInstance(zone interface{}, instance interface{}) *MockInterface_GetInstance_Call {
-	return &MockInterface_GetInstance_Call{Call: _e.mock.On("GetInstance", zone, instance)}
+func (_e *MockInterface_Expecter) GetInstance(ctx interface{}, zone interface{}, instance interface{}) *MockInterface_GetInstance_Call {
+	return &MockInterface_GetInstance_Call{Call: _e.mock.On("GetInstance", ctx, zone, instance)}
 }
 
-func (_c *MockInterface_GetInstance_Call) Run(run func(zone string, instance string)) *MockInterface_GetInstance_Call {
+func (_c *MockInterface_GetInstance_Call) Run(run func(ctx context.Context, zone string, instance string)) *MockInterface_GetInstance_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -298,22 +305,22 @@ func (_c *MockInterface_GetInstance_Call) Return(instance1 *compute.Instance, er
 	return _c
 }
 
-func (_c *MockInterface_GetInstance_Call) RunAndReturn(run func(zone string, instance string) (*compute.Instance, error)) *MockInterface_GetInstance_Call {
+func (_c *MockInterface_GetInstance_Call) RunAndReturn(run func(ctx context.Context, zone string, instance string) (*compute.Instance, error)) *MockInterface_GetInstance_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // InsertFirewallRule provides a mock function for the type MockInterface
-func (_mock *MockInterface) InsertFirewallRule(projectID string, rule *compute.Firewall) error {
-	ret := _mock.Called(projectID, rule)
+func (_mock *MockInterface) InsertFirewallRule(ctx context.Context, projectID string, rule *compute.Firewall) error {
+	ret := _mock.Called(ctx, projectID, rule)
 
 	if len(ret) == 0 {
 		panic("no return value specified for InsertFirewallRule")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, *compute.Firewall) error); ok {
-		r0 = returnFunc(projectID, rule)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *compute.Firewall) error); ok {
+		r0 = returnFunc(ctx, projectID, rule)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -326,15 +333,16 @@ type MockInterface_InsertFirewallRule_Call struct {
 }
 
 // InsertFirewallRule is a helper method to define mock.On call
+//   - ctx
 //   - projectID
 //   - rule
-func (_e *MockInterface_Expecter) InsertFirewallRule(projectID interface{}, rule interface{}) *MockInterface_InsertFirewallRule_Call {
-	return &MockInterface_InsertFirewallRule_Call{Call: _e.mock.On("InsertFirewallRule", projectID, rule)}
+func (_e *MockInterface_Expecter) InsertFirewallRule(ctx interface{}, projectID interface{}, rule interface{}) *MockInterface_InsertFirewallRule_Call {
+	return &MockInterface_InsertFirewallRule_Call{Call: _e.mock.On("InsertFirewallRule", ctx, projectID, rule)}
 }
 
-func (_c *MockInterface_InsertFirewallRule_Call) Run(run func(projectID string, rule *compute.Firewall)) *MockInterface_InsertFirewallRule_Call {
+func (_c *MockInterface_InsertFirewallRule_Call) Run(run func(ctx context.Context, projectID string, rule *compute.Firewall)) *MockInterface_InsertFirewallRule_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(*compute.Firewall))
+		run(args[0].(context.Context), args[1].(string), args[2].(*compute.Firewall))
 	})
 	return _c
 }
@@ -344,14 +352,14 @@ func (_c *MockInterface_InsertFirewallRule_Call) Return(err error) *MockInterfac
 	return _c
 }
 
-func (_c *MockInterface_InsertFirewallRule_Call) RunAndReturn(run func(projectID string, rule *compute.Firewall) error) *MockInterface_InsertFirewallRule_Call {
+func (_c *MockInterface_InsertFirewallRule_Call) RunAndReturn(run func(ctx context.Context, projectID string, rule *compute.Firewall) error) *MockInterface_InsertFirewallRule_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // InstanceHasPublicIP provides a mock function for the type MockInterface
-func (_mock *MockInterface) InstanceHasPublicIP(instance *compute.Instance) (bool, error) {
-	ret := _mock.Called(instance)
+func (_mock *MockInterface) InstanceHasPublicIP(ctx context.Context, instance *compute.Instance) (bool, error) {
+	ret := _mock.Called(ctx, instance)
 
 	if len(ret) == 0 {
 		panic("no return value specified for InstanceHasPublicIP")
@@ -359,16 +367,16 @@ func (_mock *MockInterface) InstanceHasPublicIP(instance *compute.Instance) (boo
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*compute.Instance) (bool, error)); ok {
-		return returnFunc(instance)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *compute.Instance) (bool, error)); ok {
+		return returnFunc(ctx, instance)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*compute.Instance) bool); ok {
-		r0 = returnFunc(instance)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *compute.Instance) bool); ok {
+		r0 = returnFunc(ctx, instance)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(*compute.Instance) error); ok {
-		r1 = returnFunc(instance)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *compute.Instance) error); ok {
+		r1 = returnFunc(ctx, instance)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -381,14 +389,15 @@ type MockInterface_InstanceHasPublicIP_Call struct {
 }
 
 // InstanceHasPublicIP is a helper method to define mock.On call
+//   - ctx
 //   - instance
-func (_e *MockInterface_Expecter) InstanceHasPublicIP(instance interface{}) *MockInterface_InstanceHasPublicIP_Call {
-	return &MockInterface_InstanceHasPublicIP_Call{Call: _e.mock.On("InstanceHasPublicIP", instance)}
+func (_e *MockInterface_Expecter) InstanceHasPublicIP(ctx interface{}, instance interface{}) *MockInterface_InstanceHasPublicIP_Call {
+	return &MockInterface_InstanceHasPublicIP_Call{Call: _e.mock.On("InstanceHasPublicIP", ctx, instance)}
 }
 
-func (_c *MockInterface_InstanceHasPublicIP_Call) Run(run func(instance *compute.Instance)) *MockInterface_InstanceHasPublicIP_Call {
+func (_c *MockInterface_InstanceHasPublicIP_Call) Run(run func(ctx context.Context, instance *compute.Instance)) *MockInterface_InstanceHasPublicIP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*compute.Instance))
+		run(args[0].(context.Context), args[1].(*compute.Instance))
 	})
 	return _c
 }
@@ -398,14 +407,14 @@ func (_c *MockInterface_InstanceHasPublicIP_Call) Return(b bool, err error) *Moc
 	return _c
 }
 
-func (_c *MockInterface_InstanceHasPublicIP_Call) RunAndReturn(run func(instance *compute.Instance) (bool, error)) *MockInterface_InstanceHasPublicIP_Call {
+func (_c *MockInterface_InstanceHasPublicIP_Call) RunAndReturn(run func(ctx context.Context, instance *compute.Instance) (bool, error)) *MockInterface_InstanceHasPublicIP_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListInstances provides a mock function for the type MockInterface
-func (_mock *MockInterface) ListInstances(zone string) (*compute.InstanceList, error) {
-	ret := _mock.Called(zone)
+func (_mock *MockInterface) ListInstances(ctx context.Context, zone string) (*compute.InstanceList, error) {
+	ret := _mock.Called(ctx, zone)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListInstances")
@@ -413,18 +422,18 @@ func (_mock *MockInterface) ListInstances(zone string) (*compute.InstanceList, e
 
 	var r0 *compute.InstanceList
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*compute.InstanceList, error)); ok {
-		return returnFunc(zone)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*compute.InstanceList, error)); ok {
+		return returnFunc(ctx, zone)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *compute.InstanceList); ok {
-		r0 = returnFunc(zone)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *compute.InstanceList); ok {
+		r0 = returnFunc(ctx, zone)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*compute.InstanceList)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(zone)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, zone)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -437,14 +446,15 @@ type MockInterface_ListInstances_Call struct {
 }
 
 // ListInstances is a helper method to define mock.On call
+//   - ctx
 //   - zone
-func (_e *MockInterface_Expecter) ListInstances(zone interface{}) *MockInterface_ListInstances_Call {
-	return &MockInterface_ListInstances_Call{Call: _e.mock.On("ListInstances", zone)}
+func (_e *MockInterface_Expecter) ListInstances(ctx interface{}, zone interface{}) *MockInterface_ListInstances_Call {
+	return &MockInterface_ListInstances_Call{Call: _e.mock.On("ListInstances", ctx, zone)}
 }
 
-func (_c *MockInterface_ListInstances_Call) Run(run func(zone string)) *MockInterface_ListInstances_Call {
+func (_c *MockInterface_ListInstances_Call) Run(run func(ctx context.Context, zone string)) *MockInterface_ListInstances_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -454,14 +464,14 @@ func (_c *MockInterface_ListInstances_Call) Return(instanceList *compute.Instanc
 	return _c
 }
 
-func (_c *MockInterface_ListInstances_Call) RunAndReturn(run func(zone string) (*compute.InstanceList, error)) *MockInterface_ListInstances_Call {
+func (_c *MockInterface_ListInstances_Call) RunAndReturn(run func(ctx context.Context, zone string) (*compute.InstanceList, error)) *MockInterface_ListInstances_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListZones provides a mock function for the type MockInterface
-func (_mock *MockInterface) ListZones() (*compute.ZoneList, error) {
-	ret := _mock.Called()
+func (_mock *MockInterface) ListZones(ctx context.Context) (*compute.ZoneList, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListZones")
@@ -469,18 +479,18 @@ func (_mock *MockInterface) ListZones() (*compute.ZoneList, error) {
 
 	var r0 *compute.ZoneList
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (*compute.ZoneList, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (*compute.ZoneList, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() *compute.ZoneList); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) *compute.ZoneList); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*compute.ZoneList)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -493,13 +503,14 @@ type MockInterface_ListZones_Call struct {
 }
 
 // ListZones is a helper method to define mock.On call
-func (_e *MockInterface_Expecter) ListZones() *MockInterface_ListZones_Call {
-	return &MockInterface_ListZones_Call{Call: _e.mock.On("ListZones")}
+//   - ctx
+func (_e *MockInterface_Expecter) ListZones(ctx interface{}) *MockInterface_ListZones_Call {
+	return &MockInterface_ListZones_Call{Call: _e.mock.On("ListZones", ctx)}
 }
 
-func (_c *MockInterface_ListZones_Call) Run(run func()) *MockInterface_ListZones_Call {
+func (_c *MockInterface_ListZones_Call) Run(run func(ctx context.Context)) *MockInterface_ListZones_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -509,22 +520,22 @@ func (_c *MockInterface_ListZones_Call) Return(zoneList *compute.ZoneList, err e
 	return _c
 }
 
-func (_c *MockInterface_ListZones_Call) RunAndReturn(run func() (*compute.ZoneList, error)) *MockInterface_ListZones_Call {
+func (_c *MockInterface_ListZones_Call) RunAndReturn(run func(ctx context.Context) (*compute.ZoneList, error)) *MockInterface_ListZones_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateFirewallRule provides a mock function for the type MockInterface
-func (_mock *MockInterface) UpdateFirewallRule(projectID string, name string, rule *compute.Firewall) error {
-	ret := _mock.Called(projectID, name, rule)
+func (_mock *MockInterface) UpdateFirewallRule(ctx context.Context, projectID string, name string, rule *compute.Firewall) error {
+	ret := _mock.Called(ctx, projectID, name, rule)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateFirewallRule")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, *compute.Firewall) error); ok {
-		r0 = returnFunc(projectID, name, rule)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *compute.Firewall) error); ok {
+		r0 = returnFunc(ctx, projectID, name, rule)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -537,16 +548,17 @@ type MockInterface_UpdateFirewallRule_Call struct {
 }
 
 // UpdateFirewallRule is a helper method to define mock.On call
+//   - ctx
 //   - projectID
 //   - name
 //   - rule
-func (_e *MockInterface_Expecter) UpdateFirewallRule(projectID interface{}, name interface{}, rule interface{}) *MockInterface_UpdateFirewallRule_Call {
-	return &MockInterface_UpdateFirewallRule_Call{Call: _e.mock.On("UpdateFirewallRule", projectID, name, rule)}
+func (_e *MockInterface_Expecter) UpdateFirewallRule(ctx interface{}, projectID interface{}, name interface{}, rule interface{}) *MockInterface_UpdateFirewallRule_Call {
+	return &MockInterface_UpdateFirewallRule_Call{Call: _e.mock.On("UpdateFirewallRule", ctx, projectID, name, rule)}
 }
 
-func (_c *MockInterface_UpdateFirewallRule_Call) Run(run func(projectID string, name string, rule *compute.Firewall)) *MockInterface_UpdateFirewallRule_Call {
+func (_c *MockInterface_UpdateFirewallRule_Call) Run(run func(ctx context.Context, projectID string, name string, rule *compute.Firewall)) *MockInterface_UpdateFirewallRule_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(*compute.Firewall))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(*compute.Firewall))
 	})
 	return _c
 }
@@ -556,22 +568,22 @@ func (_c *MockInterface_UpdateFirewallRule_Call) Return(err error) *MockInterfac
 	return _c
 }
 
-func (_c *MockInterface_UpdateFirewallRule_Call) RunAndReturn(run func(projectID string, name string, rule *compute.Firewall) error) *MockInterface_UpdateFirewallRule_Call {
+func (_c *MockInterface_UpdateFirewallRule_Call) RunAndReturn(run func(ctx context.Context, projectID string, name string, rule *compute.Firewall) error) *MockInterface_UpdateFirewallRule_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateInstanceNetworkTags provides a mock function for the type MockInterface
-func (_mock *MockInterface) UpdateInstanceNetworkTags(project string, zone string, instance string, tags *compute.Tags) error {
-	ret := _mock.Called(project, zone, instance, tags)
+func (_mock *MockInterface) UpdateInstanceNetworkTags(ctx context.Context, project string, zone string, instance string, tags *compute.Tags) error {
+	ret := _mock.Called(ctx, project, zone, instance, tags)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateInstanceNetworkTags")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string, *compute.Tags) error); ok {
-		r0 = returnFunc(project, zone, instance, tags)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *compute.Tags) error); ok {
+		r0 = returnFunc(ctx, project, zone, instance, tags)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -584,17 +596,18 @@ type MockInterface_UpdateInstanceNetworkTags_Call struct {
 }
 
 // UpdateInstanceNetworkTags is a helper method to define mock.On call
+//   - ctx
 //   - project
 //   - zone
 //   - instance
 //   - tags
-func (_e *MockInterface_Expecter) UpdateInstanceNetworkTags(project interface{}, zone interface{}, instance interface{}, tags interface{}) *MockInterface_UpdateInstanceNetworkTags_Call {
-	return &MockInterface_UpdateInstanceNetworkTags_Call{Call: _e.mock.On("UpdateInstanceNetworkTags", project, zone, instance, tags)}
+func (_e *MockInterface_Expecter) UpdateInstanceNetworkTags(ctx interface{}, project interface{}, zone interface{}, instance interface{}, tags interface{}) *MockInterface_UpdateInstanceNetworkTags_Call {
+	return &MockInterface_UpdateInstanceNetworkTags_Call{Call: _e.mock.On("UpdateInstanceNetworkTags", ctx, project, zone, instance, tags)}
 }
 
-func (_c *MockInterface_UpdateInstanceNetworkTags_Call) Run(run func(project string, zone string, instance string, tags *compute.Tags)) *MockInterface_UpdateInstanceNetworkTags_Call {
+func (_c *MockInterface_UpdateInstanceNetworkTags_Call) Run(run func(ctx context.Context, project string, zone string, instance string, tags *compute.Tags)) *MockInterface_UpdateInstanceNetworkTags_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string), args[3].(*compute.Tags))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(*compute.Tags))
 	})
 	return _c
 }
@@ -604,7 +617,7 @@ func (_c *MockInterface_UpdateInstanceNetworkTags_Call) Return(err error) *MockI
 	return _c
 }
 
-func (_c *MockInterface_UpdateInstanceNetworkTags_Call) RunAndReturn(run func(project string, zone string, instance string, tags *compute.Tags) error) *MockInterface_UpdateInstanceNetworkTags_Call {
+func (_c *MockInterface_UpdateInstanceNetworkTags_Call) RunAndReturn(run func(ctx context.Context, project string, zone string, instance string, tags *compute.Tags) error) *MockInterface_UpdateInstanceNetworkTags_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/gcp/cloud_info.go
+++ b/pkg/gcp/cloud_info.go
@@ -19,6 +19,8 @@ limitations under the License.
 package gcp
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	gcpclient "github.com/submariner-io/cloud-prepare/pkg/gcp/client"
@@ -37,11 +39,11 @@ type CloudInfo struct {
 // Open expected ports by creating related firewall rule.
 // - if the firewall rule is not found, we will create it.
 // - if the firewall rule is found and changed, we will update it.
-func (c *CloudInfo) openPorts(rules ...*compute.Firewall) error {
+func (c *CloudInfo) openPorts(ctx context.Context, rules ...*compute.Firewall) error {
 	for _, rule := range rules {
-		_, err := c.Client.GetFirewallRule(c.ProjectID, rule.Name)
+		_, err := c.Client.GetFirewallRule(ctx, c.ProjectID, rule.Name)
 		if gcpclient.IsGCPNotFoundError(err) {
-			if err := c.Client.InsertFirewallRule(c.ProjectID, rule); err != nil {
+			if err := c.Client.InsertFirewallRule(ctx, c.ProjectID, rule); err != nil {
 				return errors.Wrapf(err, "error inserting firewall rule %#v", rule)
 			}
 
@@ -52,7 +54,7 @@ func (c *CloudInfo) openPorts(rules ...*compute.Firewall) error {
 			return errors.Wrapf(err, "error retrieving firewall rule %q", rule.Name)
 		}
 
-		if err := c.Client.UpdateFirewallRule(c.ProjectID, rule.Name, rule); err != nil {
+		if err := c.Client.UpdateFirewallRule(ctx, c.ProjectID, rule.Name, rule); err != nil {
 			return errors.Wrapf(err, "error updating firewall rule %#v", rule)
 		}
 	}
@@ -60,10 +62,10 @@ func (c *CloudInfo) openPorts(rules ...*compute.Firewall) error {
 	return nil
 }
 
-func (c *CloudInfo) deleteFirewallRule(name string, status reporter.Interface) error {
+func (c *CloudInfo) deleteFirewallRule(ctx context.Context, name string, status reporter.Interface) error {
 	status.Start("Deleting firewall rule %q on GCP", name)
 
-	if err := c.Client.DeleteFirewallRule(c.ProjectID, name); err != nil {
+	if err := c.Client.DeleteFirewallRule(ctx, c.ProjectID, name); err != nil {
 		if !gcpclient.IsGCPNotFoundError(err) {
 			return status.Error(err, "unable to delete firewall rule %q", name)
 		}

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -47,13 +47,13 @@ func NewCloud(info CloudInfo, //nolint: gocritic //Ignore 'hugeParam' - pass by 
 	return gcpCloud
 }
 
-func (gc *gcpCloud) OpenPorts(_ context.Context, ports []api.PortSpec, status reporter.Interface) error {
+func (gc *gcpCloud) OpenPorts(ctx context.Context, ports []api.PortSpec, status reporter.Interface) error {
 	// Create the inbound firewall rule for submariner internal ports.
 	status.Start("Opening internal ports %q for intra-cluster communications on GCP", formatPorts(ports))
 	defer status.End()
 
 	internalIngress := newInternalFirewallRule(gc.ProjectID, gc.InfraID, gc.VpcName, ports)
-	if err := gc.openPorts(internalIngress); err != nil {
+	if err := gc.openPorts(ctx, internalIngress); err != nil {
 		return status.Error(err, "unable to open ports")
 	}
 
@@ -63,11 +63,11 @@ func (gc *gcpCloud) OpenPorts(_ context.Context, ports []api.PortSpec, status re
 	return nil
 }
 
-func (gc *gcpCloud) ClosePorts(_ context.Context, status reporter.Interface) error {
+func (gc *gcpCloud) ClosePorts(ctx context.Context, status reporter.Interface) error {
 	// Delete the inbound and outbound firewall rules to close submariner internal ports.
 	internalIngressName := generateRuleName(gc.InfraID, internalPortsRuleName)
 
-	return gc.deleteFirewallRule(internalIngressName, status)
+	return gc.deleteFirewallRule(ctx, internalIngressName, status)
 }
 
 func formatPorts(ports []api.PortSpec) string {

--- a/pkg/gcp/gcp.go
+++ b/pkg/gcp/gcp.go
@@ -19,6 +19,7 @@ limitations under the License.
 package gcp
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -46,7 +47,7 @@ func NewCloud(info CloudInfo, //nolint: gocritic //Ignore 'hugeParam' - pass by 
 	return gcpCloud
 }
 
-func (gc *gcpCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {
+func (gc *gcpCloud) OpenPorts(_ context.Context, ports []api.PortSpec, status reporter.Interface) error {
 	// Create the inbound firewall rule for submariner internal ports.
 	status.Start("Opening internal ports %q for intra-cluster communications on GCP", formatPorts(ports))
 	defer status.End()
@@ -62,7 +63,7 @@ func (gc *gcpCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) e
 	return nil
 }
 
-func (gc *gcpCloud) ClosePorts(status reporter.Interface) error {
+func (gc *gcpCloud) ClosePorts(_ context.Context, status reporter.Interface) error {
 	// Delete the inbound and outbound firewall rules to close submariner internal ports.
 	internalIngressName := generateRuleName(gc.InfraID, internalPortsRuleName)
 

--- a/pkg/gcp/gcp_cloud_test.go
+++ b/pkg/gcp/gcp_cloud_test.go
@@ -60,17 +60,19 @@ func testOpenPorts() {
 
 	When("the firewall rule doesn't exist", func() {
 		BeforeEach(func() {
-			t.gcpClient.EXPECT().GetFirewallRule(projectID, ingressRuleName).Return(nil, &googleapi.Error{Code: http.StatusNotFound})
+			t.gcpClient.EXPECT().GetFirewallRule(mock.Anything, projectID, ingressRuleName).Return(
+				nil, &googleapi.Error{Code: http.StatusNotFound})
 		})
 
 		Context("", func() {
 			var actualRule *compute.Firewall
 
 			BeforeEach(func() {
-				t.gcpClient.EXPECT().InsertFirewallRule(projectID, mock.Anything).RunAndReturn(func(_ string, rule *compute.Firewall) error {
-					actualRule = rule
-					return nil
-				})
+				t.gcpClient.EXPECT().InsertFirewallRule(mock.Anything, projectID, mock.Anything).RunAndReturn(
+					func(_ context.Context, _ string, rule *compute.Firewall) error {
+						actualRule = rule
+						return nil
+					})
 			})
 
 			It("should correctly insert it", func() {
@@ -83,7 +85,7 @@ func testOpenPorts() {
 
 		Context("and insertion fails", func() {
 			BeforeEach(func() {
-				t.gcpClient.EXPECT().InsertFirewallRule(projectID, mock.Anything).Return(errors.New("fake insert error"))
+				t.gcpClient.EXPECT().InsertFirewallRule(mock.Anything, projectID, mock.Anything).Return(errors.New("fake insert error"))
 			})
 
 			It("should return an error", func() {
@@ -94,17 +96,18 @@ func testOpenPorts() {
 
 	When("the firewall rule already exists", func() {
 		BeforeEach(func() {
-			t.gcpClient.EXPECT().GetFirewallRule(projectID, ingressRuleName).RunAndReturn(func(_, ruleName string) (*compute.Firewall, error) {
-				return &compute.Firewall{Name: ruleName}, nil
-			})
+			t.gcpClient.EXPECT().GetFirewallRule(mock.Anything, projectID, ingressRuleName).RunAndReturn(
+				func(_ context.Context, _, ruleName string) (*compute.Firewall, error) {
+					return &compute.Firewall{Name: ruleName}, nil
+				})
 		})
 
 		Context("", func() {
 			var actualRule *compute.Firewall
 
 			BeforeEach(func() {
-				t.gcpClient.EXPECT().UpdateFirewallRule(projectID, ingressRuleName, mock.Anything).RunAndReturn(
-					func(_, _ string, rule *compute.Firewall) error {
+				t.gcpClient.EXPECT().UpdateFirewallRule(mock.Anything, projectID, ingressRuleName, mock.Anything).RunAndReturn(
+					func(_ context.Context, _, _ string, rule *compute.Firewall) error {
 						actualRule = rule
 						return nil
 					})
@@ -120,7 +123,8 @@ func testOpenPorts() {
 
 		Context("and update fails", func() {
 			BeforeEach(func() {
-				t.gcpClient.EXPECT().UpdateFirewallRule(projectID, ingressRuleName, mock.Anything).Return(errors.New("fake update error"))
+				t.gcpClient.EXPECT().UpdateFirewallRule(mock.Anything, projectID, ingressRuleName, mock.Anything).Return(
+					errors.New("fake update error"))
 			})
 
 			It("should return an error", func() {
@@ -131,7 +135,8 @@ func testOpenPorts() {
 
 	When("retrieval of the firewall rule fails", func() {
 		BeforeEach(func() {
-			t.gcpClient.EXPECT().GetFirewallRule(projectID, ingressRuleName).Return(nil, errors.New("fake get error"))
+			t.gcpClient.EXPECT().GetFirewallRule(mock.Anything, projectID, ingressRuleName).Return(
+				nil, errors.New("fake get error"))
 		})
 
 		It("should return an error", func() {
@@ -151,7 +156,7 @@ func testClosePorts() {
 
 	Context("on success", func() {
 		BeforeEach(func() {
-			t.gcpClient.EXPECT().DeleteFirewallRule(projectID, ingressRuleName).Return(nil)
+			t.gcpClient.EXPECT().DeleteFirewallRule(mock.Anything, projectID, ingressRuleName).Return(nil)
 		})
 
 		It("should delete the firewall rule", func() {
@@ -161,7 +166,8 @@ func testClosePorts() {
 
 	When("the firewall rule doesn't exist", func() {
 		BeforeEach(func() {
-			t.gcpClient.EXPECT().DeleteFirewallRule(projectID, ingressRuleName).Return(&googleapi.Error{Code: http.StatusNotFound})
+			t.gcpClient.EXPECT().DeleteFirewallRule(mock.Anything, projectID, ingressRuleName).Return(
+				&googleapi.Error{Code: http.StatusNotFound})
 		})
 
 		It("should succeed", func() {
@@ -171,7 +177,7 @@ func testClosePorts() {
 
 	When("deletion fails", func() {
 		BeforeEach(func() {
-			t.gcpClient.EXPECT().DeleteFirewallRule(projectID, ingressRuleName).Return(errors.New("fake delete error"))
+			t.gcpClient.EXPECT().DeleteFirewallRule(mock.Anything, projectID, ingressRuleName).Return(errors.New("fake delete error"))
 		})
 
 		It("should return an error", func() {

--- a/pkg/gcp/gcp_cloud_test.go
+++ b/pkg/gcp/gcp_cloud_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package gcp_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -45,7 +46,7 @@ func testOpenPorts() {
 	var retError error
 
 	JustBeforeEach(func() {
-		retError = t.cloud.OpenPorts([]api.PortSpec{
+		retError = t.cloud.OpenPorts(context.TODO(), []api.PortSpec{
 			{
 				Port:     100,
 				Protocol: "TCP",
@@ -145,7 +146,7 @@ func testClosePorts() {
 	var retError error
 
 	JustBeforeEach(func() {
-		retError = t.cloud.ClosePorts(reporter.Stdout())
+		retError = t.cloud.ClosePorts(context.TODO(), reporter.Stdout())
 	})
 
 	Context("on success", func() {

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -73,14 +73,14 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 	defer status.End()
 
 	externalIngress := newExternalFirewallRules(d.ProjectID, d.InfraID, d.VpcName, input.PublicPorts)
-	if err := d.openPorts(externalIngress); err != nil {
+	if err := d.openPorts(ctx, externalIngress); err != nil {
 		return status.Error(err, "error creating firewall rule %q", externalIngress.Name)
 	}
 
 	status.Success("Opened External ports %q with firewall rule %q on GCP",
 		formatPorts(input.PublicPorts), externalIngress.Name)
 
-	numGatewayNodes, eligibleZonesForGW, err := d.parseCurrentGatewayInstances(status)
+	numGatewayNodes, eligibleZonesForGW, err := d.parseCurrentGatewayInstances(ctx, status)
 	if err != nil {
 		return status.Error(err, "error parsing current gateway instances")
 	}
@@ -124,8 +124,8 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 	return err
 }
 
-func (d *ocpGatewayDeployer) parseCurrentGatewayInstances(status reporter.Interface) (int, set.Set[string], error) {
-	zones, err := d.retrieveZones(status)
+func (d *ocpGatewayDeployer) parseCurrentGatewayInstances(ctx context.Context, status reporter.Interface) (int, set.Set[string], error) {
+	zones, err := d.retrieveZones(ctx, status)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -143,7 +143,7 @@ func (d *ocpGatewayDeployer) parseCurrentGatewayInstances(status reporter.Interf
 			continue
 		}
 
-		instanceList, err := d.Client.ListInstances(zone.Name)
+		instanceList, err := d.Client.ListInstances(ctx, zone.Name)
 		if err != nil {
 			return 0, nil, status.Error(err, "failed to list instances in zone %q of project %q", zone.Name, d.ProjectID)
 		}
@@ -253,14 +253,14 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 	status.Start("Retrieving the Submariner gateway firewall rules")
 	defer status.End()
 
-	err := d.deleteExternalFWRules(status)
+	err := d.deleteExternalFWRules(ctx, status)
 	if err != nil {
 		return status.Error(err, "failed to delete the gateway firewall rules in the project %q", d.ProjectID)
 	}
 
 	status.Success("Successfully deleted the firewall rules")
 
-	zones, err := d.retrieveZones(status)
+	zones, err := d.retrieveZones(ctx, status)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 			continue
 		}
 
-		instanceList, err := d.Client.ListInstances(zone.Name)
+		instanceList, err := d.Client.ListInstances(ctx, zone.Name)
 		if err != nil {
 			return status.Error(err, "failed to list instances in zone %q of project %q", zone.Name, d.ProjectID)
 		}
@@ -300,7 +300,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 			} else {
 				status.Start(fmt.Sprintf("Removing the gateway configuration from instance %q", instance.Name))
 
-				err = d.resetExistingGWNode(zone.Name, instance)
+				err = d.resetExistingGWNode(ctx, zone.Name, instance)
 				if err != nil {
 					return status.Error(err, "failed to delete gateway instance %q", instance.Name)
 				}
@@ -331,10 +331,10 @@ func (d *ocpGatewayDeployer) deleteGateway(ctx context.Context, zone string) err
 	return errors.Wrapf(d.msDeployer.Delete(ctx, machineSet), "error deleting machine set %q", machineSet.GetName())
 }
 
-func (d *ocpGatewayDeployer) deleteExternalFWRules(status reporter.Interface) error {
+func (d *ocpGatewayDeployer) deleteExternalFWRules(ctx context.Context, status reporter.Interface) error {
 	ingressName := generateRuleName(d.InfraID, publicPortsRuleName)
 
-	if err := d.deleteFirewallRule(ingressName, status); err != nil {
+	if err := d.deleteFirewallRule(ctx, ingressName, status); err != nil {
 		return errors.Wrapf(err, "error deleting firewall rule %q", ingressName)
 	}
 
@@ -355,7 +355,7 @@ func (d *ocpGatewayDeployer) isInstanceGatewayNode(instance *compute.Instance) b
 	return slices.Contains(instance.Tags.Items, submarinerGatewayNodeTag)
 }
 
-func (d *ocpGatewayDeployer) resetExistingGWNode(zone string, instance *compute.Instance) error {
+func (d *ocpGatewayDeployer) resetExistingGWNode(ctx context.Context, zone string, instance *compute.Instance) error {
 	for i := range instance.Tags.Items {
 		if instance.Tags.Items[i] == submarinerGatewayNodeTag {
 			instance.Tags.Items = append(instance.Tags.Items[:i], instance.Tags.Items[i+1:]...)
@@ -367,12 +367,12 @@ func (d *ocpGatewayDeployer) resetExistingGWNode(zone string, instance *compute.
 		Fingerprint: instance.Tags.Fingerprint,
 	}
 
-	err := d.Client.UpdateInstanceNetworkTags(d.ProjectID, zone, instance.Name, tags)
+	err := d.Client.UpdateInstanceNetworkTags(ctx, d.ProjectID, zone, instance.Name, tags)
 	if err != nil {
 		return errors.Wrapf(err, "error updating network tags for GCP instance %q in zode %q", instance.Name, zone)
 	}
 
-	err = d.Client.DeletePublicIPOnInstance(instance)
+	err = d.Client.DeletePublicIPOnInstance(ctx, instance)
 	if err != nil {
 		return errors.Wrapf(err, "error deleting public IP for GCP instance %q in zode %q", instance.Name, zone)
 	}
@@ -380,11 +380,11 @@ func (d *ocpGatewayDeployer) resetExistingGWNode(zone string, instance *compute.
 	return nil
 }
 
-func (d *ocpGatewayDeployer) retrieveZones(status reporter.Interface) (*compute.ZoneList, error) {
+func (d *ocpGatewayDeployer) retrieveZones(ctx context.Context, status reporter.Interface) (*compute.ZoneList, error) {
 	status.Start("Retrieving the current zones in the project")
 	status.End()
 
-	zones, err := d.Client.ListZones()
+	zones, err := d.Client.ListZones(ctx)
 	if err != nil {
 		return nil, status.Error(err, "failed to list the zones in the project %q", d.ProjectID)
 	}

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -20,6 +20,7 @@ package gcp
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -67,7 +68,7 @@ func NewOcpGatewayDeployer(info CloudInfo, //nolint: gocritic // Ignore 'hugePar
 	}
 }
 
-func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Deploy(_ context.Context, input api.GatewayDeployInput, status reporter.Interface) error {
 	status.Start("Configuring the required firewall rules for inter-cluster traffic")
 	defer status.End()
 
@@ -248,7 +249,7 @@ func (d *ocpGatewayDeployer) deployGateway(zone string) error {
 	return errors.Wrapf(d.msDeployer.Deploy(machineSet), "error deploying machine set %q", machineSet.GetName())
 }
 
-func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Cleanup(_ context.Context, status reporter.Interface) error {
 	status.Start("Retrieving the Submariner gateway firewall rules")
 	defer status.End()
 

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -68,7 +68,7 @@ func NewOcpGatewayDeployer(info CloudInfo, //nolint: gocritic // Ignore 'hugePar
 	}
 }
 
-func (d *ocpGatewayDeployer) Deploy(_ context.Context, input api.GatewayDeployInput, status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeployInput, status reporter.Interface) error {
 	status.Start("Configuring the required firewall rules for inter-cluster traffic")
 	defer status.End()
 
@@ -103,7 +103,7 @@ func (d *ocpGatewayDeployer) Deploy(_ context.Context, input api.GatewayDeployIn
 	for _, zone := range eligibleZonesForGW.UnsortedList() {
 		status.Start("Deploying dedicated gateway node in zone %q", zone)
 
-		err = d.deployGateway(zone)
+		err = d.deployGateway(ctx, zone)
 		if err != nil {
 			return status.Error(err, "error deploying gateway for zone %q", zone)
 		}
@@ -228,14 +228,14 @@ func (d *ocpGatewayDeployer) initMachineSet(zone string) (*unstructured.Unstruct
 	return machineSet, nil
 }
 
-func (d *ocpGatewayDeployer) deployGateway(zone string) error {
+func (d *ocpGatewayDeployer) deployGateway(ctx context.Context, zone string) error {
 	machineSet, err := d.initMachineSet(zone)
 	if err != nil {
 		return err
 	}
 
 	if d.image == "" {
-		d.image, err = d.msDeployer.GetWorkerNodeImage(machineSet, d.InfraID)
+		d.image, err = d.msDeployer.GetWorkerNodeImage(ctx, machineSet, d.InfraID)
 		if err != nil {
 			return errors.Wrap(err, "error retrieving worker node image")
 		}
@@ -246,7 +246,7 @@ func (d *ocpGatewayDeployer) deployGateway(zone string) error {
 		}
 	}
 
-	return errors.Wrapf(d.msDeployer.Deploy(machineSet), "error deploying machine set %q", machineSet.GetName())
+	return errors.Wrapf(d.msDeployer.Deploy(ctx, machineSet), "error deploying machine set %q", machineSet.GetName())
 }
 
 func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interface) error {
@@ -291,7 +291,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 			if strings.HasPrefix(instance.Name, prefix) {
 				status.Start(fmt.Sprintf("Deleting the gateway instance %q", instance.Name))
 
-				err := d.deleteGateway(zone.Name)
+				err := d.deleteGateway(ctx, zone.Name)
 				if err != nil {
 					return status.Error(err, "failed to delete dedicated gateway instance %q", instance.Name)
 				}
@@ -322,13 +322,13 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 	return nil
 }
 
-func (d *ocpGatewayDeployer) deleteGateway(zone string) error {
+func (d *ocpGatewayDeployer) deleteGateway(ctx context.Context, zone string) error {
 	machineSet, err := d.initMachineSet(zone)
 	if err != nil {
 		return err
 	}
 
-	return errors.Wrapf(d.msDeployer.Delete(machineSet), "error deleting machine set %q", machineSet.GetName())
+	return errors.Wrapf(d.msDeployer.Delete(ctx, machineSet), "error deleting machine set %q", machineSet.GetName())
 }
 
 func (d *ocpGatewayDeployer) deleteExternalFWRules(status reporter.Interface) error {

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -249,7 +249,7 @@ func (d *ocpGatewayDeployer) deployGateway(zone string) error {
 	return errors.Wrapf(d.msDeployer.Deploy(machineSet), "error deploying machine set %q", machineSet.GetName())
 }
 
-func (d *ocpGatewayDeployer) Cleanup(_ context.Context, status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interface) error {
 	status.Start("Retrieving the Submariner gateway firewall rules")
 	defer status.End()
 
@@ -312,7 +312,7 @@ func (d *ocpGatewayDeployer) Cleanup(_ context.Context, status reporter.Interfac
 
 	status.Start("Removing the Submariner gateway label from worker nodes")
 
-	err = d.k8sClient.RemoveGWLabelFromWorkerNodes()
+	err = d.k8sClient.RemoveGWLabelFromWorkerNodes(ctx)
 	if err != nil {
 		return status.Error(err, "error removing the gateway label from worker nodes")
 	}

--- a/pkg/gcp/ocpgwdeployer_test.go
+++ b/pkg/gcp/ocpgwdeployer_test.go
@@ -124,8 +124,8 @@ func testDeploy() {
 		var machineSets map[string]*unstructured.Unstructured
 
 		BeforeEach(func() {
-			t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, infraID).Return("test-image", nil).Maybe()
-			t.msDeployer.EXPECT().Deploy(mock.Anything).RunAndReturn(machineSetFn(&machineSets)).Times(2)
+			t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, mock.Anything, infraID).Return("test-image", nil).Maybe()
+			t.msDeployer.EXPECT().Deploy(mock.Anything, mock.Anything).RunAndReturn(machineSetFn(&machineSets)).Times(2)
 
 			t.numGateways = 2
 		})
@@ -215,7 +215,7 @@ func testCleanup() {
 			t.instances[zone1][0].Tags.Items = []string{submarinerGatewayNodeTag}
 			t.instances[zone2][0].Tags.Items = []string{submarinerGatewayNodeTag}
 
-			t.msDeployer.EXPECT().Delete(mock.Anything).RunAndReturn(machineSetFn(&machineSets)).Times(2)
+			t.msDeployer.EXPECT().Delete(mock.Anything, mock.Anything).RunAndReturn(machineSetFn(&machineSets)).Times(2)
 		})
 
 		It("should delete them", func() {
@@ -454,10 +454,10 @@ func labelNode(node *corev1.Node) *corev1.Node {
 }
 
 //nolint:gocritic // Error: "consider `machineSets' to be of non-pointer type"
-func machineSetFn(machineSets *map[string]*unstructured.Unstructured) func(ms *unstructured.Unstructured) error {
+func machineSetFn(machineSets *map[string]*unstructured.Unstructured) func(_ context.Context, ms *unstructured.Unstructured) error {
 	*machineSets = map[string]*unstructured.Unstructured{}
 
-	return func(ms *unstructured.Unstructured) error {
+	return func(_ context.Context, ms *unstructured.Unstructured) error {
 		zone, ok, _ := unstructured.NestedString(ms.Object, "spec", "template", "spec", "providerSpec", "value", "zone")
 		Expect(ok).To(BeTrue())
 

--- a/pkg/gcp/ocpgwdeployer_test.go
+++ b/pkg/gcp/ocpgwdeployer_test.go
@@ -62,11 +62,13 @@ func testDeploy() {
 	BeforeEach(func() {
 		actualRule = nil
 
-		t.gcpClient.EXPECT().GetFirewallRule(projectID, publicPortsRuleName).Return(nil, &googleapi.Error{Code: http.StatusNotFound})
-		t.gcpClient.EXPECT().InsertFirewallRule(projectID, mock.Anything).RunAndReturn(func(_ string, rule *compute.Firewall) error {
-			actualRule = rule
-			return nil
-		})
+		t.gcpClient.EXPECT().GetFirewallRule(mock.Anything, projectID, publicPortsRuleName).Return(
+			nil, &googleapi.Error{Code: http.StatusNotFound})
+		t.gcpClient.EXPECT().InsertFirewallRule(mock.Anything, projectID, mock.Anything).RunAndReturn(
+			func(_ context.Context, _ string, rule *compute.Firewall) error {
+				actualRule = rule
+				return nil
+			})
 	})
 
 	JustBeforeEach(func() {
@@ -155,7 +157,7 @@ func testDeploy() {
 
 	When("zone retrieval fails", func() {
 		BeforeEach(func() {
-			t.gcpClient.EXPECT().ListZones().Return(nil, errors.New("fake error"))
+			t.gcpClient.EXPECT().ListZones(mock.Anything).Return(nil, errors.New("fake error"))
 		})
 
 		It("should return an error", func() {
@@ -177,7 +179,7 @@ func testCleanup() {
 	})
 
 	JustBeforeEach(func() {
-		t.gcpClient.EXPECT().DeleteFirewallRule(projectID, publicPortsRuleName).Return(deleteFirewallRule)
+		t.gcpClient.EXPECT().DeleteFirewallRule(mock.Anything, projectID, publicPortsRuleName).Return(deleteFirewallRule)
 		retError = t.gwDeployer.Cleanup(context.TODO(), reporter.Stdout())
 	})
 
@@ -229,7 +231,7 @@ func testCleanup() {
 
 	When("zone retrieval fails", func() {
 		BeforeEach(func() {
-			t.gcpClient.EXPECT().ListZones().Return(nil, errors.New("fake error"))
+			t.gcpClient.EXPECT().ListZones(mock.Anything).Return(nil, errors.New("fake error"))
 		})
 
 		It("should return an error", func() {
@@ -307,26 +309,28 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 	})
 
 	JustBeforeEach(func() {
-		t.gcpClient.EXPECT().ListZones().Return(&compute.ZoneList{Items: t.zones}, nil).Maybe()
-		t.gcpClient.EXPECT().ListInstances(mock.Anything).RunAndReturn(func(zone string) (*compute.InstanceList, error) {
-			list := t.instances[zone]
-			if list != nil {
-				return &compute.InstanceList{Items: list}, nil
-			}
-
-			return &compute.InstanceList{}, nil
-		}).Maybe()
-
-		t.gcpClient.EXPECT().GetInstance(mock.Anything, mock.Anything).RunAndReturn(func(zone, instance string) (*compute.Instance, error) {
-			list := t.instances[zone]
-			for _, i := range list {
-				if i.Name == instance {
-					return i, nil
+		t.gcpClient.EXPECT().ListZones(mock.Anything).Return(&compute.ZoneList{Items: t.zones}, nil).Maybe()
+		t.gcpClient.EXPECT().ListInstances(mock.Anything, mock.Anything).RunAndReturn(
+			func(_ context.Context, zone string) (*compute.InstanceList, error) {
+				list := t.instances[zone]
+				if list != nil {
+					return &compute.InstanceList{Items: list}, nil
 				}
-			}
 
-			return nil, fmt.Errorf("instance %q not found", instance)
-		}).Maybe()
+				return &compute.InstanceList{}, nil
+			}).Maybe()
+
+		t.gcpClient.EXPECT().GetInstance(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+			func(_ context.Context, zone, instance string) (*compute.Instance, error) {
+				list := t.instances[zone]
+				for _, i := range list {
+					if i.Name == instance {
+						return i, nil
+					}
+				}
+
+				return nil, fmt.Errorf("instance %q not found", instance)
+			}).Maybe()
 
 		for _, node := range t.nodes {
 			_, err := t.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
@@ -401,11 +405,11 @@ func (t *gatewayDeployerTestDriver) assertIngressRule(rule *compute.Firewall) {
 }
 
 func (t *gatewayDeployerTestDriver) expInstanceUntagged(zone string, instance *compute.Instance) {
-	t.gcpClient.EXPECT().UpdateInstanceNetworkTags(projectID, zone, instance.Name, &compute.Tags{
+	t.gcpClient.EXPECT().UpdateInstanceNetworkTags(mock.Anything, projectID, zone, instance.Name, &compute.Tags{
 		Items: []string{},
 	}).Return(nil)
 
-	t.gcpClient.EXPECT().DeletePublicIPOnInstance(instance).Return(nil)
+	t.gcpClient.EXPECT().DeletePublicIPOnInstance(mock.Anything, instance).Return(nil)
 }
 
 func (t *gatewayDeployerTestDriver) assertMachineSet(ms *unstructured.Unstructured, expImage string) {

--- a/pkg/gcp/ocpgwdeployer_test.go
+++ b/pkg/gcp/ocpgwdeployer_test.go
@@ -178,7 +178,7 @@ func testCleanup() {
 
 	JustBeforeEach(func() {
 		t.gcpClient.EXPECT().DeleteFirewallRule(projectID, publicPortsRuleName).Return(deleteFirewallRule)
-		retError = t.gwDeployer.Cleanup(reporter.Stdout())
+		retError = t.gwDeployer.Cleanup(context.TODO(), reporter.Stdout())
 	})
 
 	It("should delete the firewall rule", func() {
@@ -347,7 +347,7 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 }
 
 func (t *gatewayDeployerTestDriver) doDeploy() error {
-	return t.gwDeployer.Deploy(api.GatewayDeployInput{
+	return t.gwDeployer.Deploy(context.TODO(), api.GatewayDeployInput{
 		Gateways: t.numGateways,
 		PublicPorts: []api.PortSpec{
 			{

--- a/pkg/k8s/k8siface.go
+++ b/pkg/k8s/k8siface.go
@@ -35,11 +35,11 @@ const (
 )
 
 type Interface interface {
-	ListNodesWithLabel(labelSelector string) (*v1.NodeList, error)
-	ListGatewayNodes() (*v1.NodeList, error)
-	AddGWLabelOnNode(nodeName string) error
-	RemoveGWLabelFromWorkerNodes() error
-	RemoveGWLabelFromWorkerNode(node *v1.Node) error
+	ListNodesWithLabel(ctx context.Context, labelSelector string) (*v1.NodeList, error)
+	ListGatewayNodes(ctx context.Context) (*v1.NodeList, error)
+	AddGWLabelOnNode(ctx context.Context, nodeName string) error
+	RemoveGWLabelFromWorkerNodes(ctx context.Context) error
+	RemoveGWLabelFromWorkerNode(ctx context.Context, node *v1.Node) error
 }
 
 type k8sIface struct {
@@ -50,8 +50,8 @@ func NewInterface(clientSet kubernetes.Interface) Interface {
 	return &k8sIface{clientSet: clientSet}
 }
 
-func (k *k8sIface) ListNodesWithLabel(labelSelector string) (*v1.NodeList, error) {
-	nodes, err := k.clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+func (k *k8sIface) ListNodesWithLabel(ctx context.Context, labelSelector string) (*v1.NodeList, error) {
+	nodes, err := k.clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list the nodes in the cluster")
 	}
@@ -59,10 +59,10 @@ func (k *k8sIface) ListNodesWithLabel(labelSelector string) (*v1.NodeList, error
 	return nodes, nil
 }
 
-func (k *k8sIface) ListGatewayNodes() (*v1.NodeList, error) {
+func (k *k8sIface) ListGatewayNodes(ctx context.Context) (*v1.NodeList, error) {
 	labelSelector := SubmarinerGatewayLabel + "=true"
 
-	nodes, err := k.clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+	nodes, err := k.clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list the Gateway nodes in the cluster")
 	}
@@ -70,7 +70,7 @@ func (k *k8sIface) ListGatewayNodes() (*v1.NodeList, error) {
 	return nodes, nil
 }
 
-func (k *k8sIface) updateLabel(nodeName string, mutate func(existing *v1.Node)) error {
+func (k *k8sIface) updateLabel(ctx context.Context, nodeName string, mutate func(existing *v1.Node)) error {
 	client := &resource.InterfaceFuncs[*v1.Node]{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (*v1.Node, error) {
 			return k.clientSet.CoreV1().Nodes().Get(ctx, name, options)
@@ -80,7 +80,7 @@ func (k *k8sIface) updateLabel(nodeName string, mutate func(existing *v1.Node)) 
 		},
 	}
 
-	return errors.Wrap(util.Update[*v1.Node](context.TODO(), client, &v1.Node{
+	return errors.Wrap(util.Update[*v1.Node](ctx, client, &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 		},
@@ -90,8 +90,8 @@ func (k *k8sIface) updateLabel(nodeName string, mutate func(existing *v1.Node)) 
 	}), "error updating node")
 }
 
-func (k *k8sIface) AddGWLabelOnNode(nodeName string) error {
-	return k.updateLabel(nodeName, func(existing *v1.Node) {
+func (k *k8sIface) AddGWLabelOnNode(ctx context.Context, nodeName string) error {
+	return k.updateLabel(ctx, nodeName, func(existing *v1.Node) {
 		labels := existing.GetLabels()
 		if labels == nil {
 			labels = map[string]string{}
@@ -102,15 +102,15 @@ func (k *k8sIface) AddGWLabelOnNode(nodeName string) error {
 	})
 }
 
-func (k *k8sIface) RemoveGWLabelFromWorkerNodes() error {
-	gwNodeList, err := k.clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: SubmarinerGatewayLabel})
+func (k *k8sIface) RemoveGWLabelFromWorkerNodes(ctx context.Context) error {
+	gwNodeList, err := k.clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: SubmarinerGatewayLabel})
 	if err != nil {
 		return errors.Wrap(err, "error listing submariner gateway nodes")
 	}
 
 	gwNodes := gwNodeList.Items
 	for i := range gwNodes {
-		err = k.RemoveGWLabelFromWorkerNode(&gwNodes[i])
+		err = k.RemoveGWLabelFromWorkerNode(ctx, &gwNodes[i])
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("error removing the label from the gateway node %q", gwNodes[i].Name))
 		}
@@ -119,8 +119,8 @@ func (k *k8sIface) RemoveGWLabelFromWorkerNodes() error {
 	return nil
 }
 
-func (k *k8sIface) RemoveGWLabelFromWorkerNode(node *v1.Node) error {
-	return k.updateLabel(node.Name, func(existing *v1.Node) {
+func (k *k8sIface) RemoveGWLabelFromWorkerNode(ctx context.Context, node *v1.Node) error {
+	return k.updateLabel(ctx, node.Name, func(existing *v1.Node) {
 		delete(existing.Labels, SubmarinerGatewayLabel)
 	})
 }

--- a/pkg/k8s/k8siface_test.go
+++ b/pkg/k8s/k8siface_test.go
@@ -32,6 +32,8 @@ import (
 	kubeFake "k8s.io/client-go/kubernetes/fake"
 )
 
+var ctx = context.TODO()
+
 var _ = Describe("Interface", func() {
 	Describe("ListNodesWithLabel", testListNodesWithLabel)
 	Describe("ListGatewayNodes", testListGatewayNodes)
@@ -51,7 +53,7 @@ func testRemoveGWLabelFromWorkerNodes() {
 	})
 
 	It("should remove the label from all nodes", func() {
-		Expect(t.client.RemoveGWLabelFromWorkerNodes()).To(Succeed())
+		Expect(t.client.RemoveGWLabelFromWorkerNodes(ctx)).To(Succeed())
 		t.assertNoLabel(t.nodes[0].Name, k8s.SubmarinerGatewayLabel)
 		t.assertNoLabel(t.nodes[1].Name, k8s.SubmarinerGatewayLabel)
 		t.assertNoLabel(t.nodes[2].Name, k8s.SubmarinerGatewayLabel)
@@ -64,7 +66,7 @@ func testRemoveGWLabelFromWorkerNodes() {
 		})
 
 		It("should return an error", func() {
-			Expect(t.client.RemoveGWLabelFromWorkerNodes()).ToNot(Succeed())
+			Expect(t.client.RemoveGWLabelFromWorkerNodes(ctx)).ToNot(Succeed())
 		})
 	})
 }
@@ -78,7 +80,7 @@ func testAddGWLabelOnNode() {
 
 	When("the gateway label isn't present", func() {
 		It("should add it", func() {
-			Expect(t.client.AddGWLabelOnNode("node")).To(Succeed())
+			Expect(t.client.AddGWLabelOnNode(ctx, "node")).To(Succeed())
 			t.assertLabel(t.nodes[0].Name, k8s.SubmarinerGatewayLabel, "true")
 			t.assertLabel(t.nodes[0].Name, "foo", "bar")
 		})
@@ -90,7 +92,7 @@ func testAddGWLabelOnNode() {
 		})
 
 		It("should set it to true", func() {
-			Expect(t.client.AddGWLabelOnNode(t.nodes[0].Name)).To(Succeed())
+			Expect(t.client.AddGWLabelOnNode(ctx, t.nodes[0].Name)).To(Succeed())
 			t.assertLabel(t.nodes[0].Name, k8s.SubmarinerGatewayLabel, "true")
 		})
 	})
@@ -101,7 +103,7 @@ func testAddGWLabelOnNode() {
 		})
 
 		It("should not try to update it", func() {
-			Expect(t.client.AddGWLabelOnNode(t.nodes[0].Name)).To(Succeed())
+			Expect(t.client.AddGWLabelOnNode(ctx, t.nodes[0].Name)).To(Succeed())
 
 			actualActions := t.kubeClient.Fake.Actions()
 			for i := range actualActions {
@@ -118,7 +120,7 @@ func testAddGWLabelOnNode() {
 		})
 
 		It("should add the gateway label", func() {
-			Expect(t.client.AddGWLabelOnNode(t.nodes[0].Name)).To(Succeed())
+			Expect(t.client.AddGWLabelOnNode(ctx, t.nodes[0].Name)).To(Succeed())
 			t.assertLabel(t.nodes[0].Name, k8s.SubmarinerGatewayLabel, "true")
 		})
 	})
@@ -129,7 +131,7 @@ func testAddGWLabelOnNode() {
 		})
 
 		It("should not return an error", func() {
-			Expect(t.client.AddGWLabelOnNode("node")).To(Succeed())
+			Expect(t.client.AddGWLabelOnNode(ctx, "node")).To(Succeed())
 		})
 	})
 
@@ -139,7 +141,7 @@ func testAddGWLabelOnNode() {
 		})
 
 		It("should return an error", func() {
-			Expect(t.client.AddGWLabelOnNode(t.nodes[0].Name)).ToNot(Succeed())
+			Expect(t.client.AddGWLabelOnNode(ctx, t.nodes[0].Name)).ToNot(Succeed())
 		})
 	})
 }
@@ -157,7 +159,7 @@ func testListGatewayNodes() {
 	})
 
 	It("should return the correct nodes", func() {
-		list, err := t.client.ListGatewayNodes()
+		list, err := t.client.ListGatewayNodes(ctx)
 		Expect(err).To(Succeed())
 
 		assertNodeNames(list, "node-1", "node-2")
@@ -169,7 +171,7 @@ func testListGatewayNodes() {
 		})
 
 		It("should return an error", func() {
-			_, err := t.client.ListGatewayNodes()
+			_, err := t.client.ListGatewayNodes(ctx)
 			Expect(err).ToNot(Succeed())
 		})
 	})
@@ -199,7 +201,7 @@ func testListNodesWithLabel() {
 		})
 
 		It("should return an error", func() {
-			_, err := t.client.ListNodesWithLabel("")
+			_, err := t.client.ListNodesWithLabel(ctx, "")
 			Expect(err).ToNot(Succeed())
 		})
 	})
@@ -233,7 +235,7 @@ func newInterfaceTestDriver() *interfaceTestDriver {
 }
 
 func (t *interfaceTestDriver) testListNodesWithLabel(labelSelector string, expNodes ...string) {
-	list, err := t.client.ListNodesWithLabel(labelSelector)
+	list, err := t.client.ListNodesWithLabel(ctx, labelSelector)
 	Expect(err).To(Succeed())
 
 	assertNodeNames(list, expNodes...)

--- a/pkg/ocp/fake/machineset.go
+++ b/pkg/ocp/fake/machineset.go
@@ -22,6 +22,8 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -54,16 +56,16 @@ func (_m *MockMachineSetDeployer) EXPECT() *MockMachineSetDeployer_Expecter {
 }
 
 // Delete provides a mock function for the type MockMachineSetDeployer
-func (_mock *MockMachineSetDeployer) Delete(machineSet *unstructured.Unstructured) error {
-	ret := _mock.Called(machineSet)
+func (_mock *MockMachineSetDeployer) Delete(ctx context.Context, machineSet *unstructured.Unstructured) error {
+	ret := _mock.Called(ctx, machineSet)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*unstructured.Unstructured) error); ok {
-		r0 = returnFunc(machineSet)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured) error); ok {
+		r0 = returnFunc(ctx, machineSet)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -76,14 +78,15 @@ type MockMachineSetDeployer_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
+//   - ctx
 //   - machineSet
-func (_e *MockMachineSetDeployer_Expecter) Delete(machineSet interface{}) *MockMachineSetDeployer_Delete_Call {
-	return &MockMachineSetDeployer_Delete_Call{Call: _e.mock.On("Delete", machineSet)}
+func (_e *MockMachineSetDeployer_Expecter) Delete(ctx interface{}, machineSet interface{}) *MockMachineSetDeployer_Delete_Call {
+	return &MockMachineSetDeployer_Delete_Call{Call: _e.mock.On("Delete", ctx, machineSet)}
 }
 
-func (_c *MockMachineSetDeployer_Delete_Call) Run(run func(machineSet *unstructured.Unstructured)) *MockMachineSetDeployer_Delete_Call {
+func (_c *MockMachineSetDeployer_Delete_Call) Run(run func(ctx context.Context, machineSet *unstructured.Unstructured)) *MockMachineSetDeployer_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*unstructured.Unstructured))
+		run(args[0].(context.Context), args[1].(*unstructured.Unstructured))
 	})
 	return _c
 }
@@ -93,22 +96,22 @@ func (_c *MockMachineSetDeployer_Delete_Call) Return(err error) *MockMachineSetD
 	return _c
 }
 
-func (_c *MockMachineSetDeployer_Delete_Call) RunAndReturn(run func(machineSet *unstructured.Unstructured) error) *MockMachineSetDeployer_Delete_Call {
+func (_c *MockMachineSetDeployer_Delete_Call) RunAndReturn(run func(ctx context.Context, machineSet *unstructured.Unstructured) error) *MockMachineSetDeployer_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteByName provides a mock function for the type MockMachineSetDeployer
-func (_mock *MockMachineSetDeployer) DeleteByName(name string, namespace string) error {
-	ret := _mock.Called(name, namespace)
+func (_mock *MockMachineSetDeployer) DeleteByName(ctx context.Context, name string, namespace string) error {
+	ret := _mock.Called(ctx, name, namespace)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteByName")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(name, namespace)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, name, namespace)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -121,15 +124,16 @@ type MockMachineSetDeployer_DeleteByName_Call struct {
 }
 
 // DeleteByName is a helper method to define mock.On call
+//   - ctx
 //   - name
 //   - namespace
-func (_e *MockMachineSetDeployer_Expecter) DeleteByName(name interface{}, namespace interface{}) *MockMachineSetDeployer_DeleteByName_Call {
-	return &MockMachineSetDeployer_DeleteByName_Call{Call: _e.mock.On("DeleteByName", name, namespace)}
+func (_e *MockMachineSetDeployer_Expecter) DeleteByName(ctx interface{}, name interface{}, namespace interface{}) *MockMachineSetDeployer_DeleteByName_Call {
+	return &MockMachineSetDeployer_DeleteByName_Call{Call: _e.mock.On("DeleteByName", ctx, name, namespace)}
 }
 
-func (_c *MockMachineSetDeployer_DeleteByName_Call) Run(run func(name string, namespace string)) *MockMachineSetDeployer_DeleteByName_Call {
+func (_c *MockMachineSetDeployer_DeleteByName_Call) Run(run func(ctx context.Context, name string, namespace string)) *MockMachineSetDeployer_DeleteByName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -139,22 +143,22 @@ func (_c *MockMachineSetDeployer_DeleteByName_Call) Return(err error) *MockMachi
 	return _c
 }
 
-func (_c *MockMachineSetDeployer_DeleteByName_Call) RunAndReturn(run func(name string, namespace string) error) *MockMachineSetDeployer_DeleteByName_Call {
+func (_c *MockMachineSetDeployer_DeleteByName_Call) RunAndReturn(run func(ctx context.Context, name string, namespace string) error) *MockMachineSetDeployer_DeleteByName_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Deploy provides a mock function for the type MockMachineSetDeployer
-func (_mock *MockMachineSetDeployer) Deploy(machineSet *unstructured.Unstructured) error {
-	ret := _mock.Called(machineSet)
+func (_mock *MockMachineSetDeployer) Deploy(ctx context.Context, machineSet *unstructured.Unstructured) error {
+	ret := _mock.Called(ctx, machineSet)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Deploy")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*unstructured.Unstructured) error); ok {
-		r0 = returnFunc(machineSet)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured) error); ok {
+		r0 = returnFunc(ctx, machineSet)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -167,14 +171,15 @@ type MockMachineSetDeployer_Deploy_Call struct {
 }
 
 // Deploy is a helper method to define mock.On call
+//   - ctx
 //   - machineSet
-func (_e *MockMachineSetDeployer_Expecter) Deploy(machineSet interface{}) *MockMachineSetDeployer_Deploy_Call {
-	return &MockMachineSetDeployer_Deploy_Call{Call: _e.mock.On("Deploy", machineSet)}
+func (_e *MockMachineSetDeployer_Expecter) Deploy(ctx interface{}, machineSet interface{}) *MockMachineSetDeployer_Deploy_Call {
+	return &MockMachineSetDeployer_Deploy_Call{Call: _e.mock.On("Deploy", ctx, machineSet)}
 }
 
-func (_c *MockMachineSetDeployer_Deploy_Call) Run(run func(machineSet *unstructured.Unstructured)) *MockMachineSetDeployer_Deploy_Call {
+func (_c *MockMachineSetDeployer_Deploy_Call) Run(run func(ctx context.Context, machineSet *unstructured.Unstructured)) *MockMachineSetDeployer_Deploy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*unstructured.Unstructured))
+		run(args[0].(context.Context), args[1].(*unstructured.Unstructured))
 	})
 	return _c
 }
@@ -184,14 +189,14 @@ func (_c *MockMachineSetDeployer_Deploy_Call) Return(err error) *MockMachineSetD
 	return _c
 }
 
-func (_c *MockMachineSetDeployer_Deploy_Call) RunAndReturn(run func(machineSet *unstructured.Unstructured) error) *MockMachineSetDeployer_Deploy_Call {
+func (_c *MockMachineSetDeployer_Deploy_Call) RunAndReturn(run func(ctx context.Context, machineSet *unstructured.Unstructured) error) *MockMachineSetDeployer_Deploy_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetWorkerNodeImage provides a mock function for the type MockMachineSetDeployer
-func (_mock *MockMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured.Unstructured, infraID string) (string, error) {
-	ret := _mock.Called(machineSet, infraID)
+func (_mock *MockMachineSetDeployer) GetWorkerNodeImage(ctx context.Context, machineSet *unstructured.Unstructured, infraID string) (string, error) {
+	ret := _mock.Called(ctx, machineSet, infraID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetWorkerNodeImage")
@@ -199,16 +204,16 @@ func (_mock *MockMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*unstructured.Unstructured, string) (string, error)); ok {
-		return returnFunc(machineSet, infraID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured, string) (string, error)); ok {
+		return returnFunc(ctx, machineSet, infraID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*unstructured.Unstructured, string) string); ok {
-		r0 = returnFunc(machineSet, infraID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured, string) string); ok {
+		r0 = returnFunc(ctx, machineSet, infraID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(*unstructured.Unstructured, string) error); ok {
-		r1 = returnFunc(machineSet, infraID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *unstructured.Unstructured, string) error); ok {
+		r1 = returnFunc(ctx, machineSet, infraID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -221,15 +226,16 @@ type MockMachineSetDeployer_GetWorkerNodeImage_Call struct {
 }
 
 // GetWorkerNodeImage is a helper method to define mock.On call
+//   - ctx
 //   - machineSet
 //   - infraID
-func (_e *MockMachineSetDeployer_Expecter) GetWorkerNodeImage(machineSet interface{}, infraID interface{}) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
-	return &MockMachineSetDeployer_GetWorkerNodeImage_Call{Call: _e.mock.On("GetWorkerNodeImage", machineSet, infraID)}
+func (_e *MockMachineSetDeployer_Expecter) GetWorkerNodeImage(ctx interface{}, machineSet interface{}, infraID interface{}) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
+	return &MockMachineSetDeployer_GetWorkerNodeImage_Call{Call: _e.mock.On("GetWorkerNodeImage", ctx, machineSet, infraID)}
 }
 
-func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) Run(run func(machineSet *unstructured.Unstructured, infraID string)) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
+func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) Run(run func(ctx context.Context, machineSet *unstructured.Unstructured, infraID string)) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*unstructured.Unstructured), args[1].(string))
+		run(args[0].(context.Context), args[1].(*unstructured.Unstructured), args[2].(string))
 	})
 	return _c
 }
@@ -239,14 +245,14 @@ func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) Return(s string, err e
 	return _c
 }
 
-func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) RunAndReturn(run func(machineSet *unstructured.Unstructured, infraID string) (string, error)) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
+func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) RunAndReturn(run func(ctx context.Context, machineSet *unstructured.Unstructured, infraID string) (string, error)) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // List provides a mock function for the type MockMachineSetDeployer
-func (_mock *MockMachineSetDeployer) List() ([]unstructured.Unstructured, error) {
-	ret := _mock.Called()
+func (_mock *MockMachineSetDeployer) List(ctx context.Context) ([]unstructured.Unstructured, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for List")
@@ -254,18 +260,18 @@ func (_mock *MockMachineSetDeployer) List() ([]unstructured.Unstructured, error)
 
 	var r0 []unstructured.Unstructured
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]unstructured.Unstructured, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]unstructured.Unstructured, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() []unstructured.Unstructured); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []unstructured.Unstructured); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]unstructured.Unstructured)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -278,13 +284,14 @@ type MockMachineSetDeployer_List_Call struct {
 }
 
 // List is a helper method to define mock.On call
-func (_e *MockMachineSetDeployer_Expecter) List() *MockMachineSetDeployer_List_Call {
-	return &MockMachineSetDeployer_List_Call{Call: _e.mock.On("List")}
+//   - ctx
+func (_e *MockMachineSetDeployer_Expecter) List(ctx interface{}) *MockMachineSetDeployer_List_Call {
+	return &MockMachineSetDeployer_List_Call{Call: _e.mock.On("List", ctx)}
 }
 
-func (_c *MockMachineSetDeployer_List_Call) Run(run func()) *MockMachineSetDeployer_List_Call {
+func (_c *MockMachineSetDeployer_List_Call) Run(run func(ctx context.Context)) *MockMachineSetDeployer_List_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -294,7 +301,7 @@ func (_c *MockMachineSetDeployer_List_Call) Return(unstructureds []unstructured.
 	return _c
 }
 
-func (_c *MockMachineSetDeployer_List_Call) RunAndReturn(run func() ([]unstructured.Unstructured, error)) *MockMachineSetDeployer_List_Call {
+func (_c *MockMachineSetDeployer_List_Call) RunAndReturn(run func(ctx context.Context) ([]unstructured.Unstructured, error)) *MockMachineSetDeployer_List_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/ocp/machinesets.go
+++ b/pkg/ocp/machinesets.go
@@ -45,19 +45,19 @@ const (
 // MachineSetDeployer can deploy and delete machinesets from OCP.
 type MachineSetDeployer interface {
 	// Deploy makes sure to deploy the given machine set (creating or updating it).
-	Deploy(machineSet *unstructured.Unstructured) error
+	Deploy(ctx context.Context, machineSet *unstructured.Unstructured) error
 
 	// GetWorkerNodeImage returns the image used by OCP worker nodes.
-	GetWorkerNodeImage(machineSet *unstructured.Unstructured, infraID string) (string, error)
+	GetWorkerNodeImage(ctx context.Context, machineSet *unstructured.Unstructured, infraID string) (string, error)
 
 	// List will list all the machineSets that have the submariner.io/gateway set to "true".
-	List() ([]unstructured.Unstructured, error)
+	List(ctx context.Context) ([]unstructured.Unstructured, error)
 
 	// Delete will remove the given machineset.
-	Delete(machineSet *unstructured.Unstructured) error
+	Delete(ctx context.Context, machineSet *unstructured.Unstructured) error
 
 	// DeleteByName will remove the machineset with given name.
-	DeleteByName(name, namespace string) error
+	DeleteByName(ctx context.Context, name, namespace string) error
 }
 
 type k8sMachineSetDeployer struct {
@@ -94,7 +94,7 @@ func (msd *k8sMachineSetDeployer) clientForMsd(nameSpace string) dynamic.Resourc
 	return msd.dynamicClient.Resource(machinesetGVR).Namespace(nameSpace)
 }
 
-func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured.Unstructured, infraID string,
+func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(ctx context.Context, machineSet *unstructured.Unstructured, infraID string,
 ) (string, error) {
 	machineSetClient := msd.clientForMsd("openshift-machine-api")
 
@@ -107,7 +107,7 @@ func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured.Un
 		}
 	}
 
-	nodeList, err := machineSetClient.List(context.TODO(), metav1.ListOptions{})
+	nodeList, err := machineSetClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", errors.Wrapf(err, "error listing the machineSets")
 	}
@@ -154,25 +154,25 @@ func getImageFromMachineSet(existing *unstructured.Unstructured) string {
 	return ""
 }
 
-func (msd *k8sMachineSetDeployer) Deploy(machineSet *unstructured.Unstructured) error {
+func (msd *k8sMachineSetDeployer) Deploy(ctx context.Context, machineSet *unstructured.Unstructured) error {
 	machineSetClient, err := msd.clientFor(machineSet)
 	if err != nil {
 		return err
 	}
 
-	_, err = util.CreateOrUpdate(context.TODO(), resource.ForDynamic(machineSetClient), machineSet,
+	_, err = util.CreateOrUpdate(ctx, resource.ForDynamic(machineSetClient), machineSet,
 		util.Replace[*unstructured.Unstructured](machineSet))
 
 	return errors.Wrapf(err, "error creating machine set %#v", machineSet)
 }
 
-func (msd *k8sMachineSetDeployer) Delete(machineSet *unstructured.Unstructured) error {
+func (msd *k8sMachineSetDeployer) Delete(ctx context.Context, machineSet *unstructured.Unstructured) error {
 	machineSetClient, err := msd.clientFor(machineSet)
 	if err != nil {
 		return err
 	}
 
-	err = machineSetClient.Delete(context.TODO(), machineSet.GetName(), metav1.DeleteOptions{})
+	err = machineSetClient.Delete(ctx, machineSet.GetName(), metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
@@ -180,10 +180,10 @@ func (msd *k8sMachineSetDeployer) Delete(machineSet *unstructured.Unstructured) 
 	return errors.Wrapf(err, "error deleting machine set %q", machineSet.GetName())
 }
 
-func (msd *k8sMachineSetDeployer) DeleteByName(name, namespace string) error {
+func (msd *k8sMachineSetDeployer) DeleteByName(ctx context.Context, name, namespace string) error {
 	machineSetClient := msd.clientForMsd(namespace)
 
-	err := machineSetClient.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := machineSetClient.Delete(ctx, name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
@@ -191,10 +191,10 @@ func (msd *k8sMachineSetDeployer) DeleteByName(name, namespace string) error {
 	return errors.Wrapf(err, "error deleting machine set %q", name)
 }
 
-func (msd *k8sMachineSetDeployer) List() ([]unstructured.Unstructured, error) {
+func (msd *k8sMachineSetDeployer) List(ctx context.Context) ([]unstructured.Unstructured, error) {
 	machineSetClient := msd.clientForMsd("")
 
-	machineSetList, err := machineSetClient.List(context.TODO(), metav1.ListOptions{})
+	machineSetList, err := machineSetClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to list machinesets")
 	}

--- a/pkg/ocp/machinesets_test.go
+++ b/pkg/ocp/machinesets_test.go
@@ -37,6 +37,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
+var ctx = context.TODO()
+
 var _ = Describe("K8s MachineSetDeployer", func() {
 	const (
 		infraID        = "test-infraID"
@@ -64,7 +66,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 	Context("on GetWorkerNodeImage", func() {
 		When("no worker node exists", func() {
 			It("should return an error", func() {
-				_, err := deployer.GetWorkerNodeImage(machineSet, infraID)
+				_, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
 				Expect(err).ToNot(Succeed())
 			})
 		})
@@ -75,7 +77,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 			})
 
 			JustBeforeEach(func() {
-				_, err := msClient.Create(context.TODO(), machineSet, metav1.CreateOptions{})
+				_, err := msClient.Create(ctx, machineSet, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
 			})
 
@@ -91,7 +93,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				})
 
 				It("should return its disk image", func() {
-					image, err := deployer.GetWorkerNodeImage(machineSet, infraID)
+					image, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
 					Expect(err).To(Succeed())
 					Expect(image).To(Equal("some-image"))
 				})
@@ -99,7 +101,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 
 			Context("and has no disks", func() {
 				It("should return an error", func() {
-					_, err := deployer.GetWorkerNodeImage(machineSet, infraID)
+					_, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
 					Expect(err).ToNot(Succeed())
 				})
 			})
@@ -113,7 +115,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				})
 
 				It("should return an error", func() {
-					_, err := deployer.GetWorkerNodeImage(machineSet, infraID)
+					_, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
 					Expect(err).To(ContainErrorSubstring(expectedErr))
 				})
 			})
@@ -126,9 +128,9 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 		})
 
 		It("should successfully create the machine set", func() {
-			Expect(deployer.Deploy(machineSet)).To(Succeed())
+			Expect(deployer.Deploy(ctx, machineSet)).To(Succeed())
 
-			_, err := msClient.Get(context.TODO(), machineSetName, metav1.GetOptions{})
+			_, err := msClient.Get(ctx, machineSetName, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 		})
 	})
@@ -140,14 +142,14 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 
 		When("the machine set exists", func() {
 			BeforeEach(func() {
-				_, err := msClient.Create(context.TODO(), machineSet, metav1.CreateOptions{})
+				_, err := msClient.Create(ctx, machineSet, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
 			})
 
 			It("should successfully delete the machine set", func() {
-				Expect(deployer.Delete(machineSet)).To(Succeed())
+				Expect(deployer.Delete(ctx, machineSet)).To(Succeed())
 
-				_, err := msClient.Get(context.TODO(), machineSetName, metav1.GetOptions{})
+				_, err := msClient.Get(ctx, machineSetName, metav1.GetOptions{})
 				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			})
 
@@ -157,14 +159,14 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				})
 
 				It("should return an error", func() {
-					Expect(deployer.Delete(machineSet)).ToNot(Succeed())
+					Expect(deployer.Delete(ctx, machineSet)).ToNot(Succeed())
 				})
 			})
 		})
 
 		When("the machine set does not exist", func() {
 			It("should not return an error", func() {
-				Expect(deployer.Delete(machineSet)).To(Succeed())
+				Expect(deployer.Delete(ctx, machineSet)).To(Succeed())
 			})
 		})
 	})
@@ -173,15 +175,15 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 		When("matching and non-matching machine sets exist", func() {
 			BeforeEach(func() {
 				machineSet.SetName(machineSetName)
-				_, err := msClient.Create(context.TODO(), machineSet, metav1.CreateOptions{})
+				_, err := msClient.Create(ctx, machineSet, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
 				machineSet = newMachineSet("false")
-				_, err = msClient.Create(context.TODO(), machineSet, metav1.CreateOptions{})
+				_, err = msClient.Create(ctx, machineSet, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
 			})
 
 			It("should return only the matching machine set", func() {
-				machineSetList, err := deployer.List()
+				machineSetList, err := deployer.List(ctx)
 				Expect(err).To(Succeed())
 
 				Expect(machineSetList).To(HaveLen(1))
@@ -191,7 +193,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 
 		When("a matching machine set does not exist", func() {
 			It("should not return an error", func() {
-				machineSetList, err := deployer.List()
+				machineSetList, err := deployer.List(ctx)
 				Expect(err).To(Succeed())
 				Expect(machineSetList).To(BeEmpty())
 			})

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -136,7 +136,7 @@ func (d *ocpGatewayDeployer) deployGateway(useInternalSG bool) error {
 	return errors.Wrap(d.msDeployer.Deploy(machineSet), "failed to deploy submariner gateway node")
 }
 
-func (d *ocpGatewayDeployer) Deploy(_ context.Context, input api.GatewayDeployInput, status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeployInput, status reporter.Interface) error {
 	status.Start("Configuring the required firewall rules for inter-cluster traffic")
 	defer status.End()
 
@@ -160,7 +160,7 @@ func (d *ocpGatewayDeployer) Deploy(_ context.Context, input api.GatewayDeployIn
 		return status.Error(err, "error getting the gateway machinesets")
 	}
 
-	gwNodes, err := d.K8sClient.ListGatewayNodes()
+	gwNodes, err := d.K8sClient.ListGatewayNodes(ctx)
 	if err != nil {
 		return status.Error(err, "listing the existing gateway nodes failed")
 	}
@@ -230,7 +230,7 @@ func (d *ocpGatewayDeployer) deployDedicatedGWNode(gatewayNodesToDeploy int, use
 	return nil
 }
 
-func (d *ocpGatewayDeployer) Cleanup(_ context.Context, status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interface) error {
 	computeClient, err := NewComputeV2(d.Client, gophercloud.EndpointOpts{Region: d.Region})
 	if err != nil {
 		return status.Error(err, "error creating the compute client for the region: %q", d.Region)
@@ -267,7 +267,7 @@ func (d *ocpGatewayDeployer) Cleanup(_ context.Context, status reporter.Interfac
 		status.Success("Successfully deleted the instance")
 	}
 
-	gwNodesList, err := d.K8sClient.ListGatewayNodes()
+	gwNodesList, err := d.K8sClient.ListGatewayNodes(ctx)
 	if err != nil {
 		return status.Error(err, "error listing the Submariner gateway nodes")
 	}
@@ -287,7 +287,7 @@ func (d *ocpGatewayDeployer) Cleanup(_ context.Context, status reporter.Interfac
 
 		status.Start(fmt.Sprintf("Removing Submariner gateway label from instance %q", gwNodes[i].Name))
 
-		err = d.K8sClient.RemoveGWLabelFromWorkerNode(&gwNodes[i])
+		err = d.K8sClient.RemoveGWLabelFromWorkerNode(ctx, &gwNodes[i])
 		if err != nil {
 			return status.Error(err, "failed to cleanup gateway node %q", gwNodes[i].Name)
 		}

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -115,14 +115,14 @@ func (d *ocpGatewayDeployer) initMachineSet(useInternalSG bool) (*unstructured.U
 	return machineSet, errors.Wrap(err, "error decoding message gateway yaml")
 }
 
-func (d *ocpGatewayDeployer) deployGateway(useInternalSG bool) error {
+func (d *ocpGatewayDeployer) deployGateway(ctx context.Context, useInternalSG bool) error {
 	machineSet, err := d.initMachineSet(useInternalSG)
 	if err != nil {
 		return err
 	}
 
 	if d.image == "" {
-		d.image, err = d.msDeployer.GetWorkerNodeImage(machineSet, d.InfraID)
+		d.image, err = d.msDeployer.GetWorkerNodeImage(ctx, machineSet, d.InfraID)
 		if err != nil {
 			return errors.Wrap(err, "error getting the worker image")
 		}
@@ -133,7 +133,7 @@ func (d *ocpGatewayDeployer) deployGateway(useInternalSG bool) error {
 		}
 	}
 
-	return errors.Wrap(d.msDeployer.Deploy(machineSet), "failed to deploy submariner gateway node")
+	return errors.Wrap(d.msDeployer.Deploy(ctx, machineSet), "failed to deploy submariner gateway node")
 }
 
 func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeployInput, status reporter.Interface) error {
@@ -155,7 +155,7 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 		return status.Error(err, "creating gateway security group failed")
 	}
 
-	machineSets, err := d.msDeployer.List()
+	machineSets, err := d.msDeployer.List(ctx)
 	if err != nil {
 		return status.Error(err, "error getting the gateway machinesets")
 	}
@@ -183,11 +183,10 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 		return nil
 	}
 
-	return d.deployGWNode(input.Gateways, computeClient,
-		len(machineSets)+len(taggedExistingNodes), status)
+	return d.deployGWNode(ctx, input.Gateways, computeClient, len(machineSets)+len(taggedExistingNodes), status)
 }
 
-func (d *ocpGatewayDeployer) deployGWNode(gatewayCount int,
+func (d *ocpGatewayDeployer) deployGWNode(ctx context.Context, gatewayCount int,
 	computeClient *gophercloud.ServiceClient, numGatewayNodes int, status reporter.Interface,
 ) error {
 	// Currently, we only support increasing the number of Gateway nodes which could be a valid use-case
@@ -205,20 +204,20 @@ func (d *ocpGatewayDeployer) deployGWNode(gatewayCount int,
 			return errSG
 		}
 
-		err = d.deployDedicatedGWNode(gatewayNodesToDeploy, isFound, status)
+		err = d.deployDedicatedGWNode(ctx, gatewayNodesToDeploy, isFound, status)
 	}
 
 	return err
 }
 
-func (d *ocpGatewayDeployer) deployDedicatedGWNode(gatewayNodesToDeploy int, useInternalSG bool,
+func (d *ocpGatewayDeployer) deployDedicatedGWNode(ctx context.Context, gatewayNodesToDeploy int, useInternalSG bool,
 	status reporter.Interface,
 ) error {
 	for i := range gatewayNodesToDeploy {
 		gwNodeName := d.InfraID + "-submariner-gw" + strconv.Itoa(i)
 		status.Start("Deploying dedicated Submariner gateway node %s", gwNodeName)
 
-		err := d.deployGateway(useInternalSG)
+		err := d.deployGateway(ctx, useInternalSG)
 		if err != nil {
 			return status.Error(err, "unable to deploy gateway")
 		}
@@ -238,7 +237,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 
 	groupName := d.InfraID + GwSecurityGroupSuffix
 
-	machineSetList, err := d.msDeployer.List()
+	machineSetList, err := d.msDeployer.List(ctx)
 	if err != nil {
 		return status.Error(err, "error listing the Submariner gateway nodes")
 	}
@@ -258,7 +257,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 
 		status.Start(fmt.Sprintf("Deleting the gateway instance %q", machineSetList[i].GetName()))
 
-		err = d.msDeployer.DeleteByName(machineSetList[i].GetName(), machineSetList[i].GetNamespace())
+		err = d.msDeployer.DeleteByName(ctx, machineSetList[i].GetName(), machineSetList[i].GetNamespace())
 		if err != nil {
 			return status.Error(err, "error deleting the gateway instance from node: %q",
 				machineSetList[i].GetName())

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -20,6 +20,7 @@ package rhos
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -135,7 +136,7 @@ func (d *ocpGatewayDeployer) deployGateway(useInternalSG bool) error {
 	return errors.Wrap(d.msDeployer.Deploy(machineSet), "failed to deploy submariner gateway node")
 }
 
-func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Deploy(_ context.Context, input api.GatewayDeployInput, status reporter.Interface) error {
 	status.Start("Configuring the required firewall rules for inter-cluster traffic")
 	defer status.End()
 
@@ -229,7 +230,7 @@ func (d *ocpGatewayDeployer) deployDedicatedGWNode(gatewayNodesToDeploy int, use
 	return nil
 }
 
-func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {
+func (d *ocpGatewayDeployer) Cleanup(_ context.Context, status reporter.Interface) error {
 	computeClient, err := NewComputeV2(d.Client, gophercloud.EndpointOpts{Region: d.Region})
 	if err != nil {
 		return status.Error(err, "error creating the compute client for the region: %q", d.Region)

--- a/pkg/rhos/ocpgwdeployer_test.go
+++ b/pkg/rhos/ocpgwdeployer_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package rhos_test
 
 import (
-	"context"
 	"slices"
 
 	"github.com/gophercloud/gophercloud"
@@ -53,7 +52,7 @@ func testDeploy() {
 	})
 
 	It("should deploy a gateway node machine set and security group rules", func() {
-		Expect(t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout())).To(Succeed())
+		Expect(t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout())).To(Succeed())
 
 		t.assertMachineSet(false, SubnetParam{
 			Filter: SubnetFilter{
@@ -79,7 +78,7 @@ func testDeploy() {
 		})
 
 		It("should deploy a gateway node machine with the subnets applied", func() {
-			Expect(t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout())).To(Succeed())
+			Expect(t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout())).To(Succeed())
 
 			t.assertMachineSet(false, SubnetParam{
 				Filter: SubnetFilter{
@@ -103,7 +102,7 @@ func testDeploy() {
 		})
 
 		It("should deploy a gateway node machine set with the internal security group", func() {
-			Expect(t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout())).To(Succeed())
+			Expect(t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout())).To(Succeed())
 			t.assertMachineSet(true)
 		})
 	})
@@ -118,7 +117,7 @@ func testDeploy() {
 		})
 
 		It("should not try to recreate it", func() {
-			Expect(t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout())).To(Succeed())
+			Expect(t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout())).To(Succeed())
 			Expect(t.securityGroupsCreated).To(BeEmpty())
 		})
 	})
@@ -131,15 +130,15 @@ func testDeploy() {
 		})
 
 		It("should open the gateway port and not deploy a machine set", func() {
-			Expect(t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout())).To(Succeed())
+			Expect(t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout())).To(Succeed())
 			t.assertServerSecGroup(gwSecurityGroup)
 		})
 
-		t.testErrors(func() error { return t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout()) },
+		t.testErrors(func() error { return t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout()) },
 			extractServersErrEntry())
 	})
 
-	t.testErrors(func() error { return t.gwDeployer.Deploy(t.gwDeployInput, reporter.Stdout()) },
+	t.testErrors(func() error { return t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout()) },
 		newComputeV2ErrEntry(),
 		newNetworkV2ErrEntry(),
 		createSecurityGroupErrEntry(),
@@ -184,17 +183,17 @@ func testCleanup() {
 	})
 
 	It("should delete the gateway machine sets and security groups", func() {
-		Expect(t.gwDeployer.Cleanup(reporter.Stdout())).To(Succeed())
+		Expect(t.gwDeployer.Cleanup(ctx, reporter.Stdout())).To(Succeed())
 		Expect(t.existingMachineSets).To(BeEmpty())
 		Expect(t.existingSecurityGroups).To(BeEmpty())
 		t.assertNoServerSecGroup(gwSecurityGroup)
 
-		node, err := t.kubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName3, metav1.GetOptions{})
+		node, err := t.kubeClient.CoreV1().Nodes().Get(ctx, nodeName3, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(node.Labels).NotTo(HaveKey(k8s.SubmarinerGatewayLabel))
 	})
 
-	t.testErrors(func() error { return t.gwDeployer.Cleanup(reporter.Stdout()) },
+	t.testErrors(func() error { return t.gwDeployer.Cleanup(ctx, reporter.Stdout()) },
 		newComputeV2ErrEntry(),
 		deleteSecurityGroupErrEntry(),
 		extractSecurityGroupsErrEntry(),
@@ -319,7 +318,7 @@ func (t *gatewayDeployerTestDriver) assertMachineSet(useInternalSG bool, expSubn
 }
 
 func (t *gatewayDeployerTestDriver) createGatewayNode(name string) {
-	_, err := t.kubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+	_, err := t.kubeClient.CoreV1().Nodes().Create(ctx, &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: map[string]string{k8s.SubmarinerGatewayLabel: "true"},

--- a/pkg/rhos/ocpgwdeployer_test.go
+++ b/pkg/rhos/ocpgwdeployer_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package rhos_test
 
 import (
+	"context"
 	"slices"
 
 	"github.com/gophercloud/gophercloud"
@@ -48,7 +49,7 @@ func testDeploy() {
 	t := newGatewayDeployerTestDriver()
 
 	BeforeEach(func() {
-		t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, testInfraID).Return(testImage, nil).Maybe()
+		t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, mock.Anything, testInfraID).Return(testImage, nil).Maybe()
 	})
 
 	It("should deploy a gateway node machine set and security group rules", func() {
@@ -238,17 +239,18 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 	})
 
 	JustBeforeEach(func() {
-		t.msDeployer.EXPECT().Deploy(mock.Anything).RunAndReturn(t.machineSetFn()).Maybe()
-		t.msDeployer.EXPECT().List().Return(slices.Clone(t.existingMachineSets), nil).Maybe()
+		t.msDeployer.EXPECT().Deploy(mock.Anything, mock.Anything).RunAndReturn(t.machineSetFn()).Maybe()
+		t.msDeployer.EXPECT().List(mock.Anything).Return(slices.Clone(t.existingMachineSets), nil).Maybe()
 
-		t.msDeployer.EXPECT().DeleteByName(mock.Anything, mock.Anything).RunAndReturn(func(msName, _ string) error {
-			t.existingMachineSets = slices.DeleteFunc(t.existingMachineSets, func(u unstructured.Unstructured) bool {
-				name, _, _ := unstructured.NestedString(u.Object, "metadata", "name")
-				return name == msName
-			})
+		t.msDeployer.EXPECT().DeleteByName(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+			func(_ context.Context, msName, _ string) error {
+				t.existingMachineSets = slices.DeleteFunc(t.existingMachineSets, func(u unstructured.Unstructured) bool {
+					name, _, _ := unstructured.NestedString(u.Object, "metadata", "name")
+					return name == msName
+				})
 
-			return nil
-		}).Maybe()
+				return nil
+			}).Maybe()
 
 		t.gwDeployer = rhos.NewOcpGatewayDeployer(rhos.CloudInfo{
 			Client:      &gophercloud.ProviderClient{},
@@ -262,8 +264,8 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 	return t
 }
 
-func (t *gatewayDeployerTestDriver) machineSetFn() func(ms *unstructured.Unstructured) error {
-	return func(ms *unstructured.Unstructured) error {
+func (t *gatewayDeployerTestDriver) machineSetFn() func(_ context.Context, ms *unstructured.Unstructured) error {
+	return func(_ context.Context, ms *unstructured.Unstructured) error {
 		t.machineSetsDeployed = append(t.machineSetsDeployed, ms)
 		return nil
 	}

--- a/pkg/rhos/rhos.go
+++ b/pkg/rhos/rhos.go
@@ -19,6 +19,8 @@ limitations under the License.
 package rhos
 
 import (
+	"context"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/submariner-io/admiral/pkg/reporter"
@@ -46,7 +48,7 @@ func NewCloud(info CloudInfo) api.Cloud { //nolint:gocritic // Ignore 'hugeParam
 	return &rhosCloud{CloudInfo: info}
 }
 
-func (rc *rhosCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) error {
+func (rc *rhosCloud) OpenPorts(_ context.Context, ports []api.PortSpec, status reporter.Interface) error {
 	status.Start("Opening internal ports for intra-cluster communications on RHOS")
 	defer status.End()
 
@@ -69,7 +71,7 @@ func (rc *rhosCloud) OpenPorts(ports []api.PortSpec, status reporter.Interface) 
 	return nil
 }
 
-func (rc *rhosCloud) ClosePorts(status reporter.Interface) error {
+func (rc *rhosCloud) ClosePorts(_ context.Context, status reporter.Interface) error {
 	status.Start("Revoking intra-cluster communication permissions")
 
 	computeClient, err := NewComputeV2(rc.Client, gophercloud.EndpointOpts{Region: rc.Region})

--- a/pkg/rhos/rhos_suite_test.go
+++ b/pkg/rhos/rhos_suite_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package rhos_test
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"strings"
@@ -54,6 +55,8 @@ const (
 	gwSecurityGroup       = testInfraID + rhos.GwSecurityGroupSuffix
 	internalSecurityGroup = testInfraID + rhos.InternalSecurityGroupSuffix
 )
+
+var ctx = context.TODO()
 
 func TestRHOS(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/rhos/rhos_test.go
+++ b/pkg/rhos/rhos_test.go
@@ -55,7 +55,7 @@ func testOpenPorts() {
 
 	When("the internal security group does not exist", func() {
 		It("should create the security group and open internal ports", func() {
-			Expect(t.cloud.OpenPorts(ports, reporter.Stdout())).To(Succeed())
+			Expect(t.cloud.OpenPorts(ctx, ports, reporter.Stdout())).To(Succeed())
 
 			Expect(t.securityGroupsCreated).To(ContainElement(internalSecurityGroup))
 
@@ -78,14 +78,14 @@ func testOpenPorts() {
 		})
 
 		It("should not recreate it but should add servers to it", func() {
-			Expect(t.cloud.OpenPorts(ports, reporter.Stdout())).To(Succeed())
+			Expect(t.cloud.OpenPorts(ctx, ports, reporter.Stdout())).To(Succeed())
 
 			Expect(t.securityGroupsCreated).To(BeEmpty())
 			t.assertServerSecGroup(internalSecurityGroup)
 		})
 	})
 
-	t.testErrors(func() error { return t.cloud.OpenPorts(ports, reporter.Stdout()) },
+	t.testErrors(func() error { return t.cloud.OpenPorts(ctx, ports, reporter.Stdout()) },
 		newComputeV2ErrEntry(),
 		newNetworkV2ErrEntry(),
 		createSecurityGroupErrEntry(),
@@ -114,12 +114,12 @@ func testClosePorts() {
 	})
 
 	It("should remove the security group from servers and delete it", func() {
-		Expect(t.cloud.ClosePorts(reporter.Stdout())).To(Succeed())
+		Expect(t.cloud.ClosePorts(ctx, reporter.Stdout())).To(Succeed())
 
 		t.assertNoServerSecGroup(internalSecurityGroup)
 	})
 
-	t.testErrors(func() error { return t.cloud.ClosePorts(reporter.Stdout()) },
+	t.testErrors(func() error { return t.cloud.ClosePorts(ctx, reporter.Stdout()) },
 		newComputeV2ErrEntry(),
 		deleteSecurityGroupErrEntry(),
 		extractSecurityGroupsErrEntry(),


### PR DESCRIPTION
See commits for details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added context support to cloud operation APIs across AWS, Azure, and GCP providers.
  * Updated port management, gateway deployment, and cleanup workflows to accept context parameters.
  * Enhanced Kubernetes node operations with context propagation for improved operation control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->