### PR TITLE
Fix loop issue in GCP resetExistingGWNode

### DIFF
--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -356,11 +356,9 @@ func (d *ocpGatewayDeployer) isInstanceGatewayNode(instance *compute.Instance) b
 }
 
 func (d *ocpGatewayDeployer) resetExistingGWNode(ctx context.Context, zone string, instance *compute.Instance) error {
-	for i := range instance.Tags.Items {
-		if instance.Tags.Items[i] == submarinerGatewayNodeTag {
-			instance.Tags.Items = append(instance.Tags.Items[:i], instance.Tags.Items[i+1:]...)
-		}
-	}
+	instance.Tags.Items = slices.DeleteFunc(instance.Tags.Items, func(tag string) bool {
+		return tag == submarinerGatewayNodeTag
+	})
 
 	tags := &compute.Tags{
 		Items:       instance.Tags.Items,


### PR DESCRIPTION
When removing the `submarinerGatewayNodeTag` from `instance.Tags.Items`, the loop modifies the slice in place but continues iterating with `i++`. If two consecutive tags need removal, or if the slice has the tag at the last position, this could cause issues.

Use `slices.DeleteFunc` instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal tag-cleanup logic during gateway node resets, preserving existing behavior while improving maintainability and reducing control-flow complexity.
  * No user-facing behavior changes expected; deployment and network tag updates remain the same.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->