### PR TITLE
AWS: remove use of WithEndpointResolverWithOptions

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -58,19 +57,7 @@ type Interface interface {
 func New(ctx context.Context, accessKeyID, secretAccessKey, region string) (Interface, error) {
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(region),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")),
-		//nolint:staticcheck // WithEndpointResolverWithOptions is deprecated - needs to be migrated to EndpointResolverV2.
-		config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
-			func(service, region string, _ ...any) (aws.Endpoint, error) {
-				if service != "route53" || region != "cn-northwest-1" {
-					return aws.Endpoint{}, &aws.EndpointNotFoundError{}
-				}
-
-				return aws.Endpoint{
-					URL:         "https://route53.amazonaws.com.cn",
-					PartitionID: "aws-cn",
-				}, nil
-			})))
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS configuration: %w", err)
 	}


### PR DESCRIPTION
This function is deprecated and would need to be migrated to use EC2 `EndpointResolverV2`. The resolver specifically checks if the endpoint is for `route53` and a region in China. However there is no direct migration for this in EC2. This was added with the original AWS implementation back in 2020 by developers in China. Based on the AWS documentation (and claude 😄 ), this code is legacy and unnecessary in EC2.

Fixes https://github.com/submariner-io/cloud-prepare/issues/951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified AWS client configuration by removing custom endpoint override logic. Route53 operations in cn-northwest-1 region now use default endpoints instead of custom configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->