### PR TITLE
Consolidate AWS client creation

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -24,9 +24,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
@@ -97,49 +94,6 @@ func NewCloud(client awsClient.Interface, infraID, region string, opts ...CloudO
 	}
 
 	return cloud
-}
-
-// NewCloudFromConfig creates a new api.Cloud instance based on an AWS configuration
-// which can prepare AWS for Submariner to be deployed on it.
-func NewCloudFromConfig(cfg *aws.Config, infraID, region string, opts ...CloudOption) api.Cloud {
-	cloud := &awsCloud{
-		client:      ec2.NewFromConfig(*cfg),
-		infraID:     infraID,
-		region:      region,
-		cloudConfig: make(map[string]any),
-	}
-
-	for _, opt := range opts {
-		opt(cloud)
-	}
-
-	return cloud
-}
-
-// NewCloudFromSettings creates a new api.Cloud instance using the given credentials file and profile
-// which can prepare AWS for Submariner to be deployed on it.
-func NewCloudFromSettings(ctx context.Context, credentialsFile, profile, infraID, region string, opts ...CloudOption) (api.Cloud, error) {
-	options := []func(*config.LoadOptions) error{config.WithRegion(region), config.WithSharedConfigProfile(profile)}
-	if credentialsFile != DefaultCredentialsFile() {
-		options = append(options, config.WithSharedCredentialsFiles([]string{credentialsFile}))
-	}
-
-	cfg, err := config.LoadDefaultConfig(ctx, options...)
-	if err != nil {
-		return nil, errors.Wrap(err, "error loading default config")
-	}
-
-	return NewCloudFromConfig(&cfg, infraID, region, opts...), nil
-}
-
-// DefaultCredentialsFile returns the default credentials file name.
-func DefaultCredentialsFile() string {
-	return config.DefaultSharedCredentialsFilename()
-}
-
-// DefaultProfile returns the default profile name.
-func DefaultProfile() string {
-	return "default"
 }
 
 func (ac *awsCloud) setSuffixes(ctx context.Context, vpcID string) error {

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -54,10 +54,39 @@ type Interface interface {
 		optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error)
 }
 
-func New(ctx context.Context, accessKeyID, secretAccessKey, region string) (Interface, error) {
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(region),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")))
+type Option = config.LoadOptionsFunc
+
+func WithCredentials(accessKeyID, secretAccessKey string) Option {
+	return config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, ""))
+}
+
+func WithCredentialsFile(file string) Option {
+	return config.WithSharedCredentialsFiles([]string{file})
+}
+
+func WithConfigProfile(p string) Option {
+	return config.WithSharedConfigProfile(p)
+}
+
+// DefaultCredentialsFile returns the default credentials file name.
+func DefaultCredentialsFile() string {
+	return config.DefaultSharedCredentialsFilename()
+}
+
+// DefaultProfile returns the default profile name.
+func DefaultProfile() string {
+	return "default"
+}
+
+func New(ctx context.Context, region string, opts ...Option) (Interface, error) {
+	options := make([]func(*config.LoadOptions) error, 0, 1+len(opts))
+	options = append(options, config.WithRegion(region))
+
+	for _, opt := range opts {
+		options = append(options, opt)
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS configuration: %w", err)
 	}

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -78,13 +78,10 @@ func DefaultProfile() string {
 	return "default"
 }
 
-func New(ctx context.Context, region string, opts ...Option) (Interface, error) {
+func New(ctx context.Context, region string, opts ...func(*config.LoadOptions) error) (Interface, error) {
 	options := make([]func(*config.LoadOptions) error, 0, 1+len(opts))
 	options = append(options, config.WithRegion(region))
-
-	for _, opt := range opts {
-		options = append(options, opt)
-	}
+	options = append(options, opts...)
 
 	cfg, err := config.LoadDefaultConfig(ctx, options...)
 	if err != nil {

--- a/pkg/aws/client/client_suite_test.go
+++ b/pkg/aws/client/client_suite_test.go
@@ -1,0 +1,31 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Client Suite")
+}

--- a/pkg/aws/client/client_test.go
+++ b/pkg/aws/client/client_test.go
@@ -1,0 +1,155 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/cloud-prepare/pkg/aws/client"
+)
+
+const (
+	testRegion          = "us-west-2"
+	testAccessKeyID     = "test-access-key"
+	testSecretAccessKey = "test-secret-key"
+	testProfileName     = "test-profile"
+)
+
+var _ = Describe("New", func() {
+	It("should return a valid client", func() {
+		c, err := client.New(context.TODO(), testRegion)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(assertEC2Client(c).Options().Region).To(Equal(testRegion))
+	})
+
+	Context("WithCredentials", func() {
+		It("should obtain the credentials directly from the values provided", func() {
+			c, err := client.New(context.TODO(), testRegion, client.WithCredentials(testAccessKeyID, testSecretAccessKey))
+			Expect(err).NotTo(HaveOccurred())
+			assertCredentials(assertEC2Client(c))
+		})
+	})
+
+	Context("WithConfigProfile", func() {
+		BeforeEach(func() {
+			_ = os.Setenv("AWS_CONFIG_FILE", createTempFile("test-aws-config", fmt.Sprintf("[profile %s]", testProfileName)))
+
+			DeferCleanup(func() {
+				_ = os.Unsetenv("AWS_CONFIG_FILE")
+				_ = os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+			})
+		})
+
+		Context("", func() {
+			BeforeEach(func() {
+				_ = os.Setenv("AWS_SHARED_CREDENTIALS_FILE", createCredentialsFile(testProfileName))
+			})
+
+			It("should obtain the credentials defined for the provided profile defined from the default credentials file", func() {
+				c, err := client.New(context.TODO(), testRegion, client.WithConfigProfile(testProfileName))
+				Expect(err).NotTo(HaveOccurred())
+				assertCredentials(assertEC2Client(c))
+			})
+		})
+
+		Context("and WithCredentialsFile", func() {
+			var credentialsFile string
+
+			BeforeEach(func() {
+				credentialsFile = createCredentialsFile(testProfileName)
+			})
+
+			It("should obtain the credentials defined for the provided profile from the provided credentials file", func() {
+				c, err := client.New(context.TODO(), testRegion, client.WithConfigProfile(testProfileName),
+					client.WithCredentialsFile(credentialsFile))
+				Expect(err).NotTo(HaveOccurred())
+				assertCredentials(assertEC2Client(c))
+			})
+		})
+	})
+
+	Context("WithCredentialsFile", func() {
+		var credentialsFile string
+
+		BeforeEach(func() {
+			credentialsFile = createCredentialsFile(client.DefaultProfile())
+		})
+
+		It("should obtain the credentials defined for the default profile from the provided credentials file", func() {
+			c, err := client.New(context.TODO(), testRegion, client.WithCredentialsFile(credentialsFile))
+			Expect(err).NotTo(HaveOccurred())
+			assertCredentials(assertEC2Client(c))
+		})
+	})
+
+	Context("with a non-existent profile", func() {
+		It("should return an error", func() {
+			_, err := client.New(context.TODO(), testRegion, client.WithConfigProfile("non-existent"))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+func assertEC2Client(c client.Interface) *ec2.Client {
+	Expect(c).NotTo(BeNil())
+	Expect(c).To(BeAssignableToTypeOf(&ec2.Client{}))
+
+	return c.(*ec2.Client)
+}
+
+func assertCredentials(c *ec2.Client) {
+	provider := c.Options().Credentials
+	Expect(provider).NotTo(BeNil())
+	creds, err := provider.Retrieve(context.TODO())
+	Expect(err).NotTo(HaveOccurred())
+	Expect(creds.AccessKeyID).To(Equal(testAccessKeyID))
+	Expect(creds.SecretAccessKey).To(Equal(testSecretAccessKey))
+}
+
+func createTempFile(name, data string) string {
+	file, err := os.CreateTemp("", name)
+	Expect(err).NotTo(HaveOccurred())
+
+	defer file.Close()
+
+	_, err = file.WriteString(data)
+	Expect(err).NotTo(HaveOccurred())
+
+	DeferCleanup(func() {
+		_ = os.Remove(file.Name())
+	})
+
+	return file.Name()
+}
+
+func createCredentialsFile(profile string) string {
+	//nolint:gosec // Hardcoded credentials aren't real.
+	const credentialsFileFmt = `
+[%s]
+aws_access_key_id = %s
+aws_secret_access_key = %s
+`
+
+	return createTempFile("test-aws-creds", fmt.Sprintf(credentialsFileFmt, profile, testAccessKeyID, testSecretAccessKey))
+}


### PR DESCRIPTION
There are 2 ways for users to create an AWS client: directly via `client.New` (used by ACM) and indirectly via `aws.NewCloudFromSettings` (used by subctl) that differ in how the credentials are specified. To simplify the interface and avoid duplication, remove `aws.NewCloudFromSettings` and merge it into `client.New`, with the credentials specified as additional parameters.

Also added unit tests for `client.New`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Options-based AWS credential/configuration with helpers for direct creds, credential files, and profiles.

* **Refactor**
  * Consolidated client initialization to the new options pattern; legacy helper constructors for AWS config/credentials removed from one provider to simplify initialization.

* **Tests**
  * Added test suite and comprehensive tests validating credential resolution across direct credentials, files, and profiles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->