### PR TITLE
AWS: replace cloudConfig map with explicit fields

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -43,7 +43,6 @@ type CloudOption func(*awsCloud)
 const (
 	WorkerSecurityGroupIDKey = "workerSecurityGroupID"
 	PublicSubnetListKey      = "PublicSubnetList"
-	VPCIDKey                 = "VPCID"
 )
 
 func WithControlPlaneSecurityGroup(id string) CloudOption {
@@ -66,7 +65,7 @@ func WithPublicSubnetList(id []string) CloudOption {
 
 func WithVPCName(name string) CloudOption {
 	return func(cloud *awsCloud) {
-		cloud.cloudConfig[VPCIDKey] = name
+		cloud.vpcID = name
 	}
 }
 
@@ -77,6 +76,7 @@ type awsCloud struct {
 	nodeSGSuffix         string
 	controlPlaneSGSuffix string
 	controlPlaneGroupID  string
+	vpcID                string
 	cloudConfig          map[string]any
 }
 
@@ -97,7 +97,7 @@ func NewCloud(client awsClient.Interface, infraID, region string, opts ...CloudO
 }
 
 func (ac *awsCloud) setSuffixes(ctx context.Context, vpcID string) error {
-	if ac.nodeSGSuffix != "" {
+	if ac.nodeSGSuffix != "" || ac.vpcID != "" {
 		return nil
 	}
 
@@ -159,11 +159,9 @@ func (ac *awsCloud) OpenPorts(ctx context.Context, ports []api.PortSpec, status 
 		return status.Error(err, "unable to retrieve the VPC ID")
 	}
 
-	if _, found := ac.cloudConfig[VPCIDKey]; !found {
-		err = ac.setSuffixes(ctx, vpcID)
-		if err != nil {
-			return status.Error(err, "unable to retrieve the security group names")
-		}
+	err = ac.setSuffixes(ctx, vpcID)
+	if err != nil {
+		return status.Error(err, "")
 	}
 
 	status.Success(messageRetrievedVPCID, vpcID)
@@ -204,11 +202,9 @@ func (ac *awsCloud) ClosePorts(ctx context.Context, status reporter.Interface) e
 		return status.Error(err, "unable to retrieve the VPC ID")
 	}
 
-	if _, found := ac.cloudConfig[VPCIDKey]; !found {
-		err = ac.setSuffixes(ctx, vpcID)
-		if err != nil {
-			return status.Error(err, "unable to retrieve the security group names")
-		}
+	err = ac.setSuffixes(ctx, vpcID)
+	if err != nil {
+		return status.Error(err, "")
 	}
 
 	status.Success(messageRetrievedVPCID, vpcID)

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -41,15 +41,14 @@ const (
 type CloudOption func(*awsCloud)
 
 const (
-	ControlPlaneSecurityGroupIDKey = "controlPlaneSecurityGroupID"
-	WorkerSecurityGroupIDKey       = "workerSecurityGroupID"
-	PublicSubnetListKey            = "PublicSubnetList"
-	VPCIDKey                       = "VPCID"
+	WorkerSecurityGroupIDKey = "workerSecurityGroupID"
+	PublicSubnetListKey      = "PublicSubnetList"
+	VPCIDKey                 = "VPCID"
 )
 
 func WithControlPlaneSecurityGroup(id string) CloudOption {
 	return func(cloud *awsCloud) {
-		cloud.cloudConfig[ControlPlaneSecurityGroupIDKey] = id
+		cloud.controlPlaneGroupID = id
 	}
 }
 
@@ -77,6 +76,7 @@ type awsCloud struct {
 	region               string
 	nodeSGSuffix         string
 	controlPlaneSGSuffix string
+	controlPlaneGroupID  string
 	cloudConfig          map[string]any
 }
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -24,7 +24,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/cloud-prepare/pkg/api"
@@ -40,8 +39,6 @@ const (
 
 type CloudOption func(*awsCloud)
 
-const PublicSubnetListKey = "PublicSubnetList"
-
 func WithControlPlaneSecurityGroup(id string) CloudOption {
 	return func(cloud *awsCloud) {
 		cloud.controlPlaneGroupID = id
@@ -54,9 +51,9 @@ func WithWorkerSecurityGroup(id string) CloudOption {
 	}
 }
 
-func WithPublicSubnetList(id []string) CloudOption {
+func WithPublicSubnetList(s []string) CloudOption {
 	return func(cloud *awsCloud) {
-		cloud.cloudConfig[PublicSubnetListKey] = id
+		cloud.publicSubnetList = s
 	}
 }
 
@@ -74,17 +71,16 @@ type awsCloud struct {
 	controlPlaneSGSuffix string
 	controlPlaneGroupID  string
 	workerGroupID        string
+	publicSubnetList     []string
 	vpcID                string
-	cloudConfig          map[string]any
 }
 
 // NewCloud creates a new api.Cloud instance which can prepare AWS for Submariner to be deployed on it.
 func NewCloud(client awsClient.Interface, infraID, region string, opts ...CloudOption) api.Cloud {
 	cloud := &awsCloud{
-		client:      client,
-		infraID:     infraID,
-		region:      region,
-		cloudConfig: make(map[string]any),
+		client:  client,
+		infraID: infraID,
+		region:  region,
 	}
 
 	for _, opt := range opts {
@@ -99,32 +95,13 @@ func (ac *awsCloud) setSuffixes(ctx context.Context, vpcID string) error {
 		return nil
 	}
 
-	var publicSubnets []types.Subnet
+	publicSubnets, err := ac.findPublicSubnets(ctx, vpcID, ac.publicFilter())
+	if err != nil {
+		return err
+	}
 
-	if subnets, exists := ac.cloudConfig[PublicSubnetListKey]; exists {
-		if subnetIDs, ok := subnets.([]string); ok && len(subnetIDs) > 0 {
-			for _, id := range subnetIDs {
-				subnet, err := ac.getSubnetByID(ctx, id)
-				if err != nil {
-					return errors.Wrapf(err, "unable to find subnet with ID %s", id)
-				}
-
-				publicSubnets = append(publicSubnets, *subnet)
-			}
-		} else {
-			return errors.New("Subnet IDs must be a valid non-empty slice of strings")
-		}
-	} else {
-		var err error
-
-		publicSubnets, err = ac.findPublicSubnets(ctx, vpcID, ac.filterByName("{infraID}*-public-{region}*"))
-		if err != nil {
-			return errors.Wrapf(err, "unable to find the public subnet")
-		}
-
-		if len(publicSubnets) == 0 {
-			return errors.New("no public subnet found")
-		}
+	if len(publicSubnets) == 0 {
+		return errors.New("unable to determine security group suffixes - no public subnet found")
 	}
 
 	pattern := fmt.Sprintf(`%s.*-subnet-public-%s.*`, regexp.QuoteMeta(ac.infraID), regexp.QuoteMeta(ac.region))

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -40,10 +40,7 @@ const (
 
 type CloudOption func(*awsCloud)
 
-const (
-	WorkerSecurityGroupIDKey = "workerSecurityGroupID"
-	PublicSubnetListKey      = "PublicSubnetList"
-)
+const PublicSubnetListKey = "PublicSubnetList"
 
 func WithControlPlaneSecurityGroup(id string) CloudOption {
 	return func(cloud *awsCloud) {
@@ -53,7 +50,7 @@ func WithControlPlaneSecurityGroup(id string) CloudOption {
 
 func WithWorkerSecurityGroup(id string) CloudOption {
 	return func(cloud *awsCloud) {
-		cloud.cloudConfig[WorkerSecurityGroupIDKey] = id
+		cloud.workerGroupID = id
 	}
 }
 
@@ -76,6 +73,7 @@ type awsCloud struct {
 	nodeSGSuffix         string
 	controlPlaneSGSuffix string
 	controlPlaneGroupID  string
+	workerGroupID        string
 	vpcID                string
 	cloudConfig          map[string]any
 }

--- a/pkg/aws/aws_cloud_test.go
+++ b/pkg/aws/aws_cloud_test.go
@@ -22,11 +22,13 @@ import (
 	"context"
 	"errors"
 
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/cloud-prepare/pkg/api"
 	"github.com/submariner-io/cloud-prepare/pkg/aws"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Cloud", func() {
@@ -37,14 +39,15 @@ var _ = Describe("Cloud", func() {
 func testOpenPorts() {
 	t := newCloudTestDriver()
 
-	var retError error
-
 	JustBeforeEach(func() {
-		t.expectDescribeVpcs(t.vpcID)
-		t.expectDescribeVpcsSigs(t.vpcID)
-		t.expectDescribePublicSubnets(t.subnets...)
+		t.expectDescribeVpcs()
+		t.expectDescribeVpcsSigs()
+		t.expectDescribePublicSubnets(t.existingSubnets...)
+		t.expectDescribeSecurityGroups(t.workerSGName, t.workerGroupID)
+	})
 
-		retError = t.cloud.OpenPorts(context.TODO(), []api.PortSpec{
+	doOpenPorts := func() error {
+		return t.cloud.OpenPorts(context.TODO(), []api.PortSpec{
 			{
 				Port:     100,
 				Protocol: "TCP",
@@ -54,99 +57,185 @@ func testOpenPorts() {
 				Protocol: "UDP",
 			},
 		}, reporter.Stdout())
-	})
+	}
 
 	When("on success", func() {
-		BeforeEach(func() {
-			Expect(retError).To(Succeed())
-
+		JustBeforeEach(func() {
 			t.expectValidateAuthorizeSecurityGroupIngress(nil)
-			t.expectDescribeSecurityGroups(masterSGName, masterGroupID)
+			t.expectDescribeSecurityGroups(t.masterSGName, t.masterGroupID)
 
-			t.expectAuthorizeSecurityGroupIngress(workerGroupID, newClusterSGRule(workerGroupID, 100, "TCP"))
-			t.expectAuthorizeSecurityGroupIngress(workerGroupID, newClusterSGRule(masterGroupID, 100, "TCP"))
-			t.expectAuthorizeSecurityGroupIngress(masterGroupID, newClusterSGRule(workerGroupID, 100, "TCP"))
+			t.expectAuthorizeSecurityGroupIngress(t.workerGroupID, newClusterSGRule(t.workerGroupID, 100, "TCP"))
+			t.expectAuthorizeSecurityGroupIngress(t.workerGroupID, newClusterSGRule(t.masterGroupID, 100, "TCP"))
+			t.expectAuthorizeSecurityGroupIngress(t.masterGroupID, newClusterSGRule(t.workerGroupID, 100, "TCP"))
 
-			t.expectAuthorizeSecurityGroupIngress(workerGroupID, newClusterSGRule(workerGroupID, 200, "UDP"))
-			t.expectAuthorizeSecurityGroupIngress(workerGroupID, newClusterSGRule(masterGroupID, 200, "UDP"))
-			t.expectAuthorizeSecurityGroupIngress(masterGroupID, newClusterSGRule(workerGroupID, 200, "UDP"))
+			t.expectAuthorizeSecurityGroupIngress(t.workerGroupID, newClusterSGRule(t.workerGroupID, 200, "UDP"))
+			t.expectAuthorizeSecurityGroupIngress(t.workerGroupID, newClusterSGRule(t.masterGroupID, 200, "UDP"))
+			t.expectAuthorizeSecurityGroupIngress(t.masterGroupID, newClusterSGRule(t.workerGroupID, 200, "UDP"))
 		})
 
 		It("should authorize the appropriate security groups ingress", func() {
-			Expect(retError).To(Succeed())
+			Expect(doOpenPorts()).To(Succeed())
+		})
+
+		Context("WithWorkerSecurityGroup", func() {
+			BeforeEach(func() {
+				t.workerGroupID = customWorkerGroup
+				t.cloudOptions = append(t.cloudOptions, aws.WithWorkerSecurityGroup(t.workerGroupID))
+			})
+
+			It("should authorize the appropriate security groups ingress", func() {
+				Expect(doOpenPorts()).To(Succeed())
+			})
+		})
+
+		Context("WithControlPlaneSecurityGroup", func() {
+			BeforeEach(func() {
+				t.masterGroupID = "custom-master-group"
+				t.cloudOptions = append(t.cloudOptions, aws.WithControlPlaneSecurityGroup(t.masterGroupID))
+			})
+
+			It("should authorize the appropriate security groups ingress", func() {
+				Expect(doOpenPorts()).To(Succeed())
+			})
+		})
+
+		Context("WithPublicSubnetList", func() {
+			BeforeEach(func() {
+				t.workerSGName = infraID + "-node"
+				t.masterSGName = infraID + "-controlplane"
+				t.existingSubnets = []types.Subnet{}
+				t.cloudOptions = append(t.cloudOptions, aws.WithPublicSubnetList([]string{customSubnet}))
+
+				t.expectDescribePublicSubnetsByID(customSubnet, types.Subnet{
+					SubnetId: ptr.To(customSubnet),
+					Tags: []types.Tag{
+						{
+							Key:   ptr.To("Name"),
+							Value: ptr.To(infraID + "-x-subnet-public-" + region + "-end"),
+						},
+					},
+				})
+			})
+
+			It("should authorize the appropriate security groups ingress", func() {
+				Expect(doOpenPorts()).To(Succeed())
+			})
+		})
+
+		PContext("WithVPCName", func() {
+			BeforeEach(func() {
+				t.existingVpcs = []types.Vpc{}
+				t.vpcID = "custom-vpc"
+				t.workerSGName = infraID
+				t.masterSGName = infraID
+				t.cloudOptions = append(t.cloudOptions, aws.WithVPCName(t.vpcID))
+			})
+
+			It("should authorize the appropriate security groups ingress", func() {
+				Expect(doOpenPorts()).To(Succeed())
+			})
 		})
 	})
 
 	When("the infra ID VPC does not exist", func() {
 		BeforeEach(func() {
-			t.vpcID = ""
+			t.existingVpcs = []types.Vpc{}
 		})
 
 		It("should return an error", func() {
-			Expect(retError).To(HaveOccurred())
+			Expect(doOpenPorts()).To(HaveOccurred())
 		})
 	})
 
 	When("authorize security group ingress validation fails", func() {
 		BeforeEach(func() {
-			t.expectDescribeVpcs(vpcID)
-			t.expectDescribePublicSubnets(t.subnets...)
+			t.expectDescribePublicSubnets(t.existingSubnets...)
 			t.expectValidateAuthorizeSecurityGroupIngress(errors.New("mock error"))
 		})
 
 		It("should return an error", func() {
-			Expect(retError).To(HaveOccurred())
+			Expect(doOpenPorts()).To(HaveOccurred())
 		})
 	})
 
 	When("retrieval of security groups fails", func() {
 		BeforeEach(func() {
 			t.expectValidateAuthorizeSecurityGroupIngress(nil)
-			t.expectDescribeSecurityGroupsFailure(masterSGName, errors.New("mock error"))
+			t.expectDescribeSecurityGroupsFailure(t.masterSGName, errors.New("mock error"))
 		})
 
 		It("should return an error", func() {
-			Expect(retError).To(HaveOccurred())
+			Expect(doOpenPorts()).To(HaveOccurred())
 		})
 	})
 }
 
 func testClosePorts() {
+	ipPerm := newIPPermission(internalTraffic + " from X to Y")
+
 	t := newCloudTestDriver()
 
-	var retError error
-
 	JustBeforeEach(func() {
-		t.expectDescribeVpcs(t.vpcID)
-		t.expectDescribeVpcsSigs(t.vpcID)
-		t.expectDescribePublicSubnets(t.subnets...)
-		t.expectDescribePublicSubnetsSigs(t.subnets...)
-
-		retError = t.cloud.ClosePorts(context.TODO(), reporter.Stdout())
+		t.expectDescribeVpcs()
+		t.expectDescribeVpcsSigs()
+		t.expectDescribePublicSubnets(t.existingSubnets...)
+		t.expectDescribePublicSubnetsSigs(t.existingSubnets...)
+		t.expectDescribeSecurityGroups(t.workerSGName, t.workerGroupID, ipPerm)
 	})
 
+	doClosePorts := func() error {
+		return t.cloud.ClosePorts(context.TODO(), reporter.Stdout())
+	}
+
 	Context("on success", func() {
-		BeforeEach(func() {
+		JustBeforeEach(func() {
+			t.expectDescribeSecurityGroups(t.workerSGName, t.workerGroupID)
 			t.expectValidateRevokeSecurityGroupIngress(nil)
 
-			ipPerm := newIPPermission(internalTraffic + " from X to Y")
-			t.expectDescribeSecurityGroups(masterSGName, masterGroupID, ipPerm, newIPPermission("other"))
+			t.expectDescribeSecurityGroups(t.masterSGName, t.masterGroupID, ipPerm, newIPPermission("other"))
 
-			t.expectRevokeSecurityGroupIngress(masterGroupID, ipPerm)
+			t.expectRevokeSecurityGroupIngress(t.masterGroupID, ipPerm)
+			t.expectRevokeSecurityGroupIngress(t.workerGroupID, ipPerm)
 		})
 
 		It("should revoke the appropriate security groups ingress", func() {
-			Expect(retError).To(Succeed())
+			Expect(doClosePorts()).To(Succeed())
+		})
+
+		Context("WithWorkerSecurityGroup", func() {
+			BeforeEach(func() {
+				t.workerGroupID = customWorkerGroup
+				t.cloudOptions = append(t.cloudOptions, aws.WithWorkerSecurityGroup(t.workerGroupID))
+
+				t.expectDescribeSecurityGroupsByID(t.workerGroupID, ipPerm)
+			})
+
+			It("should revoke the appropriate security groups ingress", func() {
+				Expect(doClosePorts()).To(Succeed())
+			})
+		})
+
+		Context("WithControlPlaneSecurityGroup", func() {
+			BeforeEach(func() {
+				t.masterGroupID = "custom-master-group"
+				t.cloudOptions = append(t.cloudOptions, aws.WithControlPlaneSecurityGroup(t.masterGroupID))
+
+				t.expectDescribeSecurityGroupsByID(t.masterGroupID, ipPerm)
+			})
+
+			It("should revoke the appropriate security groups ingress", func() {
+				Expect(doClosePorts()).To(Succeed())
+			})
 		})
 	})
 
 	When("the infra ID VPC does not exist", func() {
 		BeforeEach(func() {
-			t.vpcID = ""
+			t.existingVpcs = []types.Vpc{}
 		})
 
 		It("should return an error", func() {
-			Expect(retError).To(HaveOccurred())
+			Expect(doClosePorts()).To(HaveOccurred())
 		})
 	})
 
@@ -156,18 +245,18 @@ func testClosePorts() {
 		})
 
 		It("should return an error", func() {
-			Expect(retError).To(HaveOccurred())
+			Expect(doClosePorts()).To(HaveOccurred())
 		})
 	})
 
 	When("retrieval of security groups fails", func() {
 		BeforeEach(func() {
 			t.expectValidateRevokeSecurityGroupIngress(nil)
-			t.expectDescribeSecurityGroupsFailure(masterSGName, errors.New("mock error"))
+			t.expectDescribeSecurityGroupsFailure(t.masterSGName, errors.New("mock error"))
 		})
 
 		It("should return an error", func() {
-			Expect(retError).To(HaveOccurred())
+			Expect(doClosePorts()).To(HaveOccurred())
 		})
 	})
 }
@@ -182,10 +271,10 @@ func newCloudTestDriver() *cloudTestDriver {
 
 	BeforeEach(func() {
 		t.beforeEach()
+	})
 
-		t.cloud = aws.NewCloud(t.awsClient, infraID, region)
-
-		t.expectDescribeSecurityGroups(workerSGName, workerGroupID)
+	JustBeforeEach(func() {
+		t.cloud = aws.NewCloud(t.awsClient, infraID, region, t.cloudOptions...)
 	})
 
 	AfterEach(t.afterEach)

--- a/pkg/aws/aws_suite_test.go
+++ b/pkg/aws/aws_suite_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+	"github.com/submariner-io/cloud-prepare/pkg/aws"
 	"github.com/submariner-io/cloud-prepare/pkg/aws/client/fake"
 	"k8s.io/utils/ptr"
 )
@@ -36,22 +37,19 @@ import (
 const (
 	infraID                  = "test-infra"
 	region                   = "test-region"
-	vpcID                    = "test-vpc"
-	workerGroupID            = "worker-group"
-	masterGroupID            = "master-group"
 	gatewayGroupID           = "gateway-group"
 	internalTraffic          = "Internal Submariner traffic"
 	availabilityZone1        = "availability-zone-1"
 	availabilityZone2        = "availability-zone-2"
 	subnetID1                = "subnet-1"
 	subnetID2                = "subnet-2"
+	customSubnet             = "custom-subnet"
 	instanceImageID          = "test-image"
-	masterSGName             = infraID + "-master-sg"
-	workerSGName             = infraID + "-worker-sg"
 	gatewaySGName            = infraID + "-submariner-gw-sg"
 	providerAWSTagPrefix     = "tag:sigs.k8s.io/cluster-api-provider-aws/cluster/"
 	clusterFilterTagName     = "tag:kubernetes.io/cluster/" + infraID
 	clusterFilterTagNameSigs = providerAWSTagPrefix + infraID
+	customWorkerGroup        = "custom-worker-group"
 )
 
 var internalTrafficDesc = fmt.Sprintf("Should contain %q", internalTraffic)
@@ -64,21 +62,33 @@ func TestAWS(t *testing.T) {
 type fakeAWSClientBase struct {
 	awsClient                        *fake.MockInterface
 	vpcID                            string
-	subnets                          []types.Subnet
+	existingVpcs                     []types.Vpc
+	existingSubnets                  []types.Subnet
 	describeSubnetsErr               error
 	authorizeSecurityGroupIngressErr error
 	createTagsErr                    error
 	describeInstanceTypeOfferingsErr error
+	workerGroupID                    string
+	masterGroupID                    string
+	masterSGName                     string
+	workerSGName                     string
+	cloudOptions                     []aws.CloudOption
 }
 
 func (f *fakeAWSClientBase) beforeEach() {
 	f.awsClient = fake.NewMockInterface(GinkgoT())
-	f.vpcID = vpcID
-	f.subnets = []types.Subnet{newSubnet(availabilityZone1, subnetID1), newSubnet(availabilityZone2, subnetID2)}
+	f.vpcID = "test-vpc"
+	f.existingVpcs = []types.Vpc{{VpcId: ptr.To(f.vpcID)}}
+	f.existingSubnets = []types.Subnet{newSubnet(availabilityZone1, subnetID1), newSubnet(availabilityZone2, subnetID2)}
 	f.describeSubnetsErr = nil
 	f.authorizeSecurityGroupIngressErr = nil
 	f.createTagsErr = nil
 	f.describeInstanceTypeOfferingsErr = nil
+	f.workerGroupID = "worker-group"
+	f.masterGroupID = "master-group"
+	f.masterSGName = infraID + "-master-sg"
+	f.workerSGName = infraID + "-worker-sg"
+	f.cloudOptions = []aws.CloudOption{}
 }
 
 func (f *fakeAWSClientBase) afterEach() {
@@ -90,54 +100,42 @@ func (f *fakeAWSClientBase) expectDescribeSecurityGroups(name, groupID string, i
 		Return(newDescribeSecurityGroupsOutput(groupID, ipPermissions...), nil).Maybe()
 }
 
+func (f *fakeAWSClientBase) expectDescribeSecurityGroupsByID(groupID string, ipPermissions ...types.IpPermission) {
+	f.awsClient.EXPECT().DescribeSecurityGroups(mock.Anything, &ec2.DescribeSecurityGroupsInput{
+		GroupIds: []string{groupID},
+	}).Return(newDescribeSecurityGroupsOutput(groupID, ipPermissions...), nil).Maybe()
+}
+
 func (f *fakeAWSClientBase) expectDescribeSecurityGroupsFailure(name string, err error) {
 	f.awsClient.EXPECT().DescribeSecurityGroups(mock.Anything, newDescribeSecurityGroupsInput(f.vpcID, name)).
 		Return(nil, err).Maybe()
 }
 
-func (f *fakeAWSClientBase) expectDescribeVpcs(vpcID string) {
-	var vpcs []types.Vpc
-	if vpcID != "" {
-		vpcs = []types.Vpc{
-			{
-				VpcId: ptr.To(vpcID),
-			},
-		}
-	}
-
+func (f *fakeAWSClientBase) expectDescribeVpcs() {
 	f.awsClient.EXPECT().DescribeVpcs(mock.Anything, mock.MatchedBy(((&filtersMatcher{expectedFilters: []types.Filter{{
 		Name:   ptr.To("tag:Name"),
 		Values: []string{infraID + "-vpc"},
 	}, {
 		Name:   ptr.To(clusterFilterTagName),
 		Values: []string{"owned"},
-	}}}).Matches))).Return(&ec2.DescribeVpcsOutput{Vpcs: vpcs}, nil).Maybe()
+	}}}).Matches))).Return(&ec2.DescribeVpcsOutput{Vpcs: f.existingVpcs}, nil).Maybe()
 }
 
-func (f *fakeAWSClientBase) expectDescribeVpcsSigs(vpcID string) {
-	var vpcs []types.Vpc
-	if vpcID != "" {
-		vpcs = []types.Vpc{
-			{
-				VpcId: ptr.To(vpcID),
-			},
-		}
-	}
-
+func (f *fakeAWSClientBase) expectDescribeVpcsSigs() {
 	f.awsClient.EXPECT().DescribeVpcs(mock.Anything, mock.MatchedBy(((&filtersMatcher{expectedFilters: []types.Filter{{
 		Name:   ptr.To("tag:Name"),
 		Values: []string{infraID + "-vpc"},
 	}, {
 		Name:   ptr.To(clusterFilterTagNameSigs),
 		Values: []string{"owned"},
-	}}}).Matches))).Return(&ec2.DescribeVpcsOutput{Vpcs: vpcs}, nil).Maybe()
+	}}}).Matches))).Return(&ec2.DescribeVpcsOutput{Vpcs: f.existingVpcs}, nil).Maybe()
 }
 
 func (f *fakeAWSClientBase) expectValidateAuthorizeSecurityGroupIngress(authErr error) *mock.Call {
 	return f.awsClient.EXPECT().AuthorizeSecurityGroupIngress(mock.Anything,
 		mock.MatchedBy((&authorizeSecurityGroupIngressInputMatcher{ec2.AuthorizeSecurityGroupIngressInput{
 			DryRun:  ptr.To(true),
-			GroupId: ptr.To(workerGroupID),
+			GroupId: ptr.To(f.workerGroupID),
 		}}).Matches)).Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, authErr).Call
 }
 
@@ -160,7 +158,7 @@ func (f *fakeAWSClientBase) expectRevokeSecurityGroupIngress(groupID string, ipP
 func (f *fakeAWSClientBase) expectValidateRevokeSecurityGroupIngress(retErr error) {
 	f.awsClient.EXPECT().RevokeSecurityGroupIngress(mock.Anything, &ec2.RevokeSecurityGroupIngressInput{
 		DryRun:  ptr.To(true),
-		GroupId: ptr.To(workerGroupID),
+		GroupId: ptr.To(f.workerGroupID),
 	}).Return(&ec2.RevokeSecurityGroupIngressOutput{}, retErr)
 }
 
@@ -175,6 +173,12 @@ func (f *fakeAWSClientBase) expectDescribePublicSubnets(retSubnets ...types.Subn
 		Name:   ptr.To(clusterFilterTagName),
 		Values: []string{"owned"},
 	}}}).Matches))).Return(&ec2.DescribeSubnetsOutput{Subnets: retSubnets}, f.describeSubnetsErr).Maybe()
+}
+
+func (f *fakeAWSClientBase) expectDescribePublicSubnetsByID(subnetID string, retSubnets ...types.Subnet) {
+	f.awsClient.EXPECT().DescribeSubnets(mock.Anything, &ec2.DescribeSubnetsInput{
+		SubnetIds: []string{subnetID},
+	}).Return(&ec2.DescribeSubnetsOutput{Subnets: retSubnets}, f.describeSubnetsErr)
 }
 
 func (f *fakeAWSClientBase) expectDescribePublicSubnetsSigs(retSubnets ...types.Subnet) {
@@ -241,7 +245,7 @@ func (f *fakeAWSClientBase) expectDeleteSecurityGroup(groupID string) {
 func (f *fakeAWSClientBase) expectValidateDeleteSecurityGroup() *mock.Call {
 	return f.awsClient.EXPECT().DeleteSecurityGroup(mock.Anything, &ec2.DeleteSecurityGroupInput{
 		DryRun:  ptr.To(true),
-		GroupId: ptr.To(workerGroupID),
+		GroupId: ptr.To(f.workerGroupID),
 	}).Return(&ec2.DeleteSecurityGroupOutput{}, nil).Call
 }
 
@@ -377,6 +381,7 @@ func newDescribeSecurityGroupsOutput(groupID string, ipPermissions ...types.IpPe
 	return &ec2.DescribeSecurityGroupsOutput{SecurityGroups: []types.SecurityGroup{
 		{
 			GroupId:       ptr.To(groupID),
+			GroupName:     ptr.To(groupID + "-name"),
 			IpPermissions: ipPermissions,
 		},
 	}}

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -76,26 +76,9 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 
 	status.Start(messageValidatePrerequisites)
 
-	var publicSubnets []types.Subnet
-
-	if subnets, exists := d.aws.cloudConfig[PublicSubnetListKey]; exists {
-		if subnetIDs, ok := subnets.([]string); ok && len(subnetIDs) > 0 {
-			for _, id := range subnetIDs {
-				subnet, err := d.aws.getSubnetByID(ctx, id)
-				if err != nil {
-					return errors.Wrapf(err, "unable to find subnet with ID %s", id)
-				}
-
-				publicSubnets = append(publicSubnets, *subnet)
-			}
-		} else {
-			return errors.New("Subnet IDs must be a valid non-empty slice of strings")
-		}
-	} else {
-		publicSubnets, err = d.aws.findPublicSubnets(ctx, vpcID, d.aws.filterByName("{infraID}*-public-{region}*"))
-		if err != nil {
-			return status.Error(err, "unable to find public subnets")
-		}
+	publicSubnets, err := d.aws.findPublicSubnets(ctx, vpcID, d.aws.publicFilter())
+	if err != nil {
+		return status.Error(err, "")
 	}
 
 	err = d.validateDeployPrerequisites(ctx, vpcID, input, publicSubnets)
@@ -368,26 +351,9 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 
 	status.Success(messageValidatedPrerequisites)
 
-	var publicSubnets []types.Subnet
-
-	if subnets, exists := d.aws.cloudConfig[PublicSubnetListKey]; exists {
-		if subnetIDs, ok := subnets.([]string); ok && len(subnetIDs) > 0 {
-			for _, id := range subnetIDs {
-				subnet, err := d.aws.getSubnetByID(ctx, id)
-				if err != nil {
-					return errors.Wrapf(err, "unable to find subnet with ID %s", id)
-				}
-
-				publicSubnets = append(publicSubnets, *subnet)
-			}
-		} else {
-			return errors.New("Subnet IDs must be a valid non-empty slice of strings")
-		}
-	} else {
-		publicSubnets, err = d.aws.getTaggedPublicSubnets(ctx, vpcID)
-		if err != nil {
-			return err
-		}
+	publicSubnets, err := d.aws.findPublicSubnets(ctx, vpcID, submarinerGatewayFilter())
+	if err != nil {
+		return status.Error(err, "")
 	}
 
 	for i := range publicSubnets {
@@ -430,7 +396,7 @@ func (d *ocpGatewayDeployer) validateCleanupPrerequisites(ctx context.Context, v
 
 	errs = appendIfError(errs, d.aws.validateDeleteSecGroup(ctx, vpcID))
 
-	subnets, err := d.aws.getTaggedPublicSubnets(ctx, vpcID)
+	subnets, err := d.aws.findPublicSubnets(ctx, vpcID, submarinerGatewayFilter())
 	if err != nil {
 		return err
 	}

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -286,21 +286,17 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(ctx context.Context, gatewaySecurit
 		PublicSubnet:  extractName(publicSubnet.Tags),
 	}
 
-	if id, exists := d.aws.cloudConfig[WorkerSecurityGroupIDKey]; exists {
-		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
-			workerSecurityGroup, err := d.aws.getSecurityGroupByID(ctx, workerGroupIDStr)
-			if err != nil {
-				return nil, errors.Wrapf(err, "error finding the worker security group with ID %s", workerGroupIDStr)
-			}
-
-			if workerSecurityGroup.GroupName == nil {
-				return nil, errors.Errorf("security group with ID %s has no group name", workerGroupIDStr)
-			}
-
-			tplVars.NodeSG = *workerSecurityGroup.GroupName
-		} else {
-			return nil, errors.New("worker Security Group ID must be a valid non-empty string")
+	if d.aws.workerGroupID != "" {
+		workerSecurityGroup, err := d.aws.getSecurityGroupByID(ctx, d.aws.workerGroupID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error finding the worker security group with ID %s", d.aws.workerGroupID)
 		}
+
+		if workerSecurityGroup.GroupName == nil {
+			return nil, errors.Errorf("security group with ID %s has no group name", d.aws.workerGroupID)
+		}
+
+		tplVars.NodeSG = *workerSecurityGroup.GroupName
 	} else {
 		tplVars.NodeSG = d.aws.infraID + d.aws.nodeSGSuffix
 	}

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -69,11 +69,9 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 
 	status.Success(messageRetrievedVPCID, vpcID)
 
-	if _, found := d.aws.cloudConfig[VPCIDKey]; !found {
-		err = d.aws.setSuffixes(ctx, vpcID)
-		if err != nil {
-			return status.Error(err, "unable to retrieve the security group names")
-		}
+	err = d.aws.setSuffixes(ctx, vpcID)
+	if err != nil {
+		return status.Error(err, "")
 	}
 
 	status.Start(messageValidatePrerequisites)
@@ -360,11 +358,9 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 
 	status.Success(messageRetrievedVPCID, vpcID)
 
-	if _, found := d.aws.cloudConfig[VPCIDKey]; !found {
-		err = d.aws.setSuffixes(ctx, vpcID)
-		if err != nil {
-			return status.Error(err, "unable to retrieve the security group names")
-		}
+	err = d.aws.setSuffixes(ctx, vpcID)
+	if err != nil {
+		return status.Error(err, "")
 	}
 
 	status.Start(messageValidatePrerequisites)

--- a/pkg/aws/ocpgwdeployer_test.go
+++ b/pkg/aws/ocpgwdeployer_test.go
@@ -48,15 +48,8 @@ func testDeploy() {
 	JustBeforeEach(func() {
 		deployCall = t.msDeployer.EXPECT().Deploy(mock.Anything, mock.Anything).RunAndReturn(machineSetFn(&t.machineSets)).Call
 
-		t.expectDescribePublicSubnets(t.subnets...)
-
-		for i := range t.subnets {
-			if t.zonesWithInstanceTypeOfferings.Has(*t.subnets[i].AvailabilityZone) {
-				t.expectDescribeInstanceTypeOfferings(t.expectedInstanceType(), *t.subnets[i].AvailabilityZone, types.InstanceTypeOffering{})
-			} else {
-				t.expectDescribeInstanceTypeOfferings(t.expectedInstanceType(), *t.subnets[i].AvailabilityZone)
-			}
-		}
+		t.expectDescribePublicSubnets(t.existingSubnets...)
+		t.setupExpectedSubnetInstanceTypeOfferings(t.existingSubnets...)
 	})
 
 	When("on success", func() {
@@ -73,8 +66,6 @@ func testDeploy() {
 			for i := range t.expectedSubnetsTagged {
 				t.expectCreateGatewayTags(*t.expectedSubnetsTagged[i].SubnetId)
 			}
-
-			t.doDeploy()
 		})
 
 		t.testDeploySuccess("", "")
@@ -90,9 +81,8 @@ func testDeploy() {
 
 		Context("and the first subnet doesn't have an instance type offering", func() {
 			BeforeEach(func() {
+				t.expectedSubnets = []types.Subnet{t.existingSubnets[1]}
 				t.zonesWithInstanceTypeOfferings = set.New(availabilityZone2)
-				t.expectedSubnetsDeployed = []types.Subnet{t.subnets[1]}
-				t.expectedSubnetsTagged = t.expectedSubnetsDeployed
 			})
 
 			t.testDeploySuccess("", "")
@@ -100,8 +90,8 @@ func testDeploy() {
 
 		Context("and the deploying subnet is already tagged", func() {
 			BeforeEach(func() {
-				t.expectedSubnetsTagged = nil
-				t.subnets[0].Tags = append(t.subnets[0].Tags, types.Tag{
+				t.expectedSubnetsTagged = []types.Subnet{}
+				t.existingSubnets[0].Tags = append(t.existingSubnets[0].Tags, types.Tag{
 					Key:   ptr.To("submariner.io/gateway"),
 					Value: ptr.To(""),
 				})
@@ -117,12 +107,53 @@ func testDeploy() {
 
 			t.testDeploySuccess("should select an instance type and", "")
 		})
+
+		Context("WithWorkerSecurityGroup", func() {
+			BeforeEach(func() {
+				t.workerGroupID = customWorkerGroup
+				t.workerSGName = t.workerGroupID + "-name"
+				t.cloudOptions = append(t.cloudOptions, aws.WithWorkerSecurityGroup(t.workerGroupID))
+
+				t.expectDescribeSecurityGroupsByID(t.workerGroupID)
+			})
+
+			t.testDeploySuccess("", "")
+		})
+
+		Context("WithVPCName", func() {
+			BeforeEach(func() {
+				t.existingVpcs = []types.Vpc{}
+				t.vpcID = "custom-vpc"
+				t.workerSGName = infraID
+				t.masterSGName = infraID
+				t.cloudOptions = append(t.cloudOptions, aws.WithVPCName(t.vpcID))
+			})
+
+			t.testDeploySuccess("", "")
+		})
+
+		Context("WithPublicSubnetList", func() {
+			BeforeEach(func() {
+				t.existingSubnets = []types.Subnet{}
+				t.cloudOptions = append(t.cloudOptions, aws.WithPublicSubnetList([]string{customSubnet}))
+
+				t.expectedSubnets = []types.Subnet{newSubnet(availabilityZone1, customSubnet)}
+				t.expectDescribePublicSubnetsByID(customSubnet, t.expectedSubnets[0])
+
+				t.zonesWithInstanceTypeOfferings = set.New(availabilityZone1)
+			})
+
+			JustBeforeEach(func() {
+				t.setupExpectedSubnetInstanceTypeOfferings(t.expectedSubnets...)
+			})
+
+			t.testDeploySuccess("", "")
+		})
 	})
 
 	Context("", func() {
 		JustBeforeEach(func() {
 			deployCall.Maybe()
-			t.doDeploy()
 		})
 
 		BeforeEach(func() {
@@ -131,11 +162,11 @@ func testDeploy() {
 
 		When("the infra ID VPC does not exist", func() {
 			BeforeEach(func() {
-				t.vpcID = ""
+				t.existingVpcs = []types.Vpc{}
 			})
 
 			It("should return an error", func() {
-				Expect(t.retError).To(HaveOccurred())
+				Expect(t.doDeploy()).To(HaveOccurred())
 			})
 		})
 
@@ -145,7 +176,7 @@ func testDeploy() {
 			})
 
 			It("should return an error", func() {
-				Expect(t.retError).To(HaveOccurred())
+				Expect(t.doDeploy()).To(HaveOccurred())
 			})
 		})
 
@@ -154,11 +185,14 @@ func testDeploy() {
 				t.createTagsErr = errors.New("mock error")
 				t.expectAuthorizeSecurityGroupIngress(gatewayGroupID, newPublicSGRule(100, "TCP"))
 				t.expectAuthorizeSecurityGroupIngress(gatewayGroupID, newPublicSGRule(200, "UDP"))
+			})
+
+			JustBeforeEach(func() {
 				t.expectCreateGatewayTags(*t.expectedSubnetsTagged[0].SubnetId)
 			})
 
 			It("should return an error", func() {
-				Expect(t.retError).To(HaveOccurred())
+				Expect(t.doDeploy()).To(HaveOccurred())
 			})
 		})
 
@@ -169,17 +203,17 @@ func testDeploy() {
 			})
 
 			It("should return an error", func() {
-				Expect(t.retError).To(HaveOccurred())
+				Expect(t.doDeploy()).To(HaveOccurred())
 			})
 		})
 
 		When("there's an insufficient number of public subnets", func() {
 			BeforeEach(func() {
-				t.subnets = nil
+				t.existingSubnets = []types.Subnet{}
 			})
 
 			It("should return an error", func() {
-				Expect(t.retError).To(HaveOccurred())
+				Expect(t.doDeploy()).To(HaveOccurred())
 			})
 		})
 	})
@@ -189,31 +223,32 @@ func testCleanup() {
 	t := newGatewayDeployerTestDriver()
 
 	JustBeforeEach(func() {
-		t.expectDescribeGatewaySubnets(t.subnets...)
-		t.doCleanup()
+		t.expectDescribeGatewaySubnets(t.existingSubnets...)
 	})
 
 	When("on success", func() {
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			t.expectCleanupValidations(true)
-			t.msDeployer.EXPECT().Delete(mock.Anything, mock.Anything).RunAndReturn(machineSetFn(&t.machineSets)).Times(len(t.subnets))
+			t.msDeployer.EXPECT().Delete(mock.Anything, mock.Anything).RunAndReturn(machineSetFn(&t.machineSets)).
+				Times(len(t.existingSubnets))
 			t.expectDeleteSecurityGroup(gatewayGroupID)
 
-			for i := range t.subnets {
-				t.expectDeleteGatewayTags(*t.subnets[i].SubnetId)
+			for i := range t.existingSubnets {
+				t.expectDeleteGatewayTags(*t.existingSubnets[i].SubnetId)
 			}
 		})
 
-		It("should delete the correct gateway node machine sets", func() {
-			Expect(t.retError).To(Succeed())
+		t.testCleanupSuccess()
 
-			for i := range t.subnets {
-				assertMachineSet(t.machineSets[*t.subnets[i].AvailabilityZone], *t.subnets[i].SubnetId, t.expectedInstanceType(),
-					"", "")
-				delete(t.machineSets, *t.subnets[i].AvailabilityZone)
-			}
+		Context("WithPublicSubnetList", func() {
+			BeforeEach(func() {
+				t.existingSubnets = []types.Subnet{newSubnet(availabilityZone1, customSubnet)}
+				t.cloudOptions = append(t.cloudOptions, aws.WithPublicSubnetList([]string{customSubnet}))
 
-			Expect(t.machineSets).To(BeEmpty(), "Unexpected machine sets deleted: %#v", t.machineSets)
+				t.expectDescribePublicSubnetsByID(customSubnet, t.existingSubnets[0])
+			})
+
+			t.testCleanupSuccess()
 		})
 	})
 
@@ -224,11 +259,11 @@ func testCleanup() {
 
 		When("the infra ID VPC does not exist", func() {
 			BeforeEach(func() {
-				t.vpcID = ""
+				t.existingVpcs = []types.Vpc{}
 			})
 
 			It("should return an error", func() {
-				Expect(t.retError).To(HaveOccurred())
+				Expect(t.doCleanup()).To(HaveOccurred())
 			})
 		})
 
@@ -238,7 +273,7 @@ func testCleanup() {
 			})
 
 			It("should return an error", func() {
-				Expect(t.retError).To(HaveOccurred())
+				Expect(t.doCleanup()).To(HaveOccurred())
 			})
 		})
 	})
@@ -248,13 +283,12 @@ type gatewayDeployerTestDriver struct {
 	fakeAWSClientBase
 	numGateways                    int
 	instanceType                   string
-	subnets                        []types.Subnet
+	expectedSubnets                []types.Subnet
 	expectedSubnetsDeployed        []types.Subnet
 	expectedSubnetsTagged          []types.Subnet
 	gatewayGroupID                 string
 	zonesWithInstanceTypeOfferings set.Set[string]
 	machineSets                    map[string]*unstructured.Unstructured
-	retError                       error
 	msDeployer                     *ocpFake.MockMachineSetDeployer
 	gwDeployer                     api.GatewayDeployer
 }
@@ -268,29 +302,41 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 		t.msDeployer = ocpFake.NewMockMachineSetDeployer(GinkgoT())
 		t.numGateways = 1
 		t.instanceType = "test-instance-type"
-		t.subnets = []types.Subnet{newSubnet(availabilityZone1, subnetID1), newSubnet(availabilityZone2, subnetID2)}
-		t.expectedSubnetsDeployed = []types.Subnet{t.subnets[0]}
-		t.expectedSubnetsTagged = []types.Subnet{t.subnets[0]}
+		t.expectedSubnets = []types.Subnet{t.existingSubnets[0]}
+		t.expectedSubnetsDeployed = nil
+		t.expectedSubnetsTagged = nil
 		t.gatewayGroupID = gatewayGroupID
-		t.zonesWithInstanceTypeOfferings = set.New[string]()
-
-		for i := range t.subnets {
-			t.zonesWithInstanceTypeOfferings.Insert(*t.subnets[i].AvailabilityZone)
-		}
+		t.zonesWithInstanceTypeOfferings = nil
 	})
 
 	JustBeforeEach(func() {
-		t.expectDescribeVpcs(t.vpcID)
+		if t.zonesWithInstanceTypeOfferings == nil {
+			t.zonesWithInstanceTypeOfferings = set.New[string]()
+			for i := range t.existingSubnets {
+				t.zonesWithInstanceTypeOfferings.Insert(*t.existingSubnets[i].AvailabilityZone)
+			}
+		}
+
+		if t.expectedSubnetsDeployed == nil {
+			t.expectedSubnetsDeployed = t.expectedSubnets
+		}
+
+		if t.expectedSubnetsTagged == nil {
+			t.expectedSubnetsTagged = t.expectedSubnets
+		}
+
+		t.expectDescribeVpcs()
 		t.expectDescribeSecurityGroups(gatewaySGName, t.gatewayGroupID)
 		t.expectDescribeInstances(instanceImageID)
-		t.expectDescribeSecurityGroups(workerSGName, workerGroupID)
-		t.expectDescribePublicSubnets(t.subnets...)
-		t.expectDescribeVpcsSigs(t.vpcID)
-		t.expectDescribePublicSubnetsSigs(t.subnets...)
+		t.expectDescribeSecurityGroups(t.workerSGName, t.workerGroupID)
+		t.expectDescribePublicSubnets(t.existingSubnets...)
+		t.expectDescribeVpcsSigs()
+		t.expectDescribePublicSubnetsSigs(t.existingSubnets...)
 
 		var err error
 
-		t.gwDeployer, err = aws.NewOcpGatewayDeployer(aws.NewCloud(t.awsClient, infraID, region), t.msDeployer, t.instanceType)
+		t.gwDeployer, err = aws.NewOcpGatewayDeployer(aws.NewCloud(t.awsClient, infraID, region, t.cloudOptions...),
+			t.msDeployer, t.instanceType)
 		Expect(err).To(Succeed())
 	})
 
@@ -305,8 +351,8 @@ func (t *gatewayDeployerTestDriver) expectedInstanceType() string {
 	return aws.PreferredInstances[0]
 }
 
-func (t *gatewayDeployerTestDriver) doDeploy() {
-	t.retError = t.gwDeployer.Deploy(context.TODO(), api.GatewayDeployInput{
+func (t *gatewayDeployerTestDriver) doDeploy() error {
+	return t.gwDeployer.Deploy(context.TODO(), api.GatewayDeployInput{
 		Gateways: t.numGateways,
 		PublicPorts: []api.PortSpec{
 			{
@@ -321,8 +367,8 @@ func (t *gatewayDeployerTestDriver) doDeploy() {
 	}, reporter.Stdout())
 }
 
-func (t *gatewayDeployerTestDriver) doCleanup() {
-	t.retError = t.gwDeployer.Cleanup(context.TODO(), reporter.Stdout())
+func (t *gatewayDeployerTestDriver) doCleanup() error {
+	return t.gwDeployer.Cleanup(context.TODO(), reporter.Stdout())
 }
 
 func (t *gatewayDeployerTestDriver) expectDeployValidations(enforce bool) {
@@ -362,10 +408,10 @@ func (t *gatewayDeployerTestDriver) testDeploySuccess(msgPrefix, msgSuffix strin
 	}
 
 	It(msg+" deploy the correct gateway node machine sets"+msgSuffix, func() {
-		Expect(t.retError).To(Succeed())
+		Expect(t.doDeploy()).To(Succeed())
 
 		for i := range t.expectedSubnetsDeployed {
-			assertMachineSet(t.machineSets[*t.expectedSubnetsDeployed[i].AvailabilityZone], *t.expectedSubnetsDeployed[i].SubnetId,
+			t.assertMachineSet(t.machineSets[*t.expectedSubnetsDeployed[i].AvailabilityZone], *t.expectedSubnetsDeployed[i].SubnetId,
 				t.expectedInstanceType(), instanceImageID, gatewaySGName)
 			delete(t.machineSets, *t.expectedSubnetsDeployed[i].AvailabilityZone)
 		}
@@ -389,7 +435,9 @@ func machineSetFn(machineSets *map[string]*unstructured.Unstructured) func(_ con
 	}
 }
 
-func assertMachineSet(ms *unstructured.Unstructured, expSubnetID, expInstanceType, expAmiID, expGatewaySG string) {
+func (t *gatewayDeployerTestDriver) assertMachineSet(ms *unstructured.Unstructured, expSubnetID, expInstanceType, expAmiID,
+	expGatewaySG string,
+) {
 	Expect(ms).ToNot(BeNil())
 
 	Expect(ms.GetLabels()).To(HaveKeyWithValue("machine.openshift.io/cluster-api-cluster", infraID))
@@ -411,7 +459,7 @@ func assertMachineSet(ms *unstructured.Unstructured, expSubnetID, expInstanceTyp
 
 	filter := sgFilters[0].(map[string]any)
 	Expect(filter).To(HaveKeyWithValue("name", "tag:Name"))
-	Expect(filter["values"]).To(ContainElements(workerSGName))
+	Expect(filter["values"]).To(ContainElements(t.workerSGName))
 
 	if expGatewaySG != "" {
 		Expect(filter["values"]).To(ContainElement(expGatewaySG))
@@ -423,4 +471,29 @@ func assertMachineSet(ms *unstructured.Unstructured, expSubnetID, expInstanceTyp
 	filter = subnetFilters[0].(map[string]any)
 	Expect(filter).To(HaveKeyWithValue("name", "tag:Name"))
 	Expect(filter["values"]).To(ContainElement(subnetName(expSubnetID)))
+}
+
+func (t *gatewayDeployerTestDriver) setupExpectedSubnetInstanceTypeOfferings(subnets ...types.Subnet) {
+	for i := range subnets {
+		if t.zonesWithInstanceTypeOfferings.Has(*subnets[i].AvailabilityZone) {
+			t.expectDescribeInstanceTypeOfferings(t.expectedInstanceType(), *subnets[i].AvailabilityZone, types.InstanceTypeOffering{})
+		} else {
+			t.expectDescribeInstanceTypeOfferings(t.expectedInstanceType(), *subnets[i].AvailabilityZone)
+		}
+	}
+}
+
+func (t *gatewayDeployerTestDriver) testCleanupSuccess() {
+	It("should delete the correct gateway node machine sets", func() {
+		Expect(t.doCleanup()).To(Succeed())
+
+		for i := range t.existingSubnets {
+			subnet := &t.existingSubnets[i]
+			t.assertMachineSet(t.machineSets[*subnet.AvailabilityZone], *subnet.SubnetId, t.expectedInstanceType(),
+				"", "")
+			delete(t.machineSets, *subnet.AvailabilityZone)
+		}
+
+		Expect(t.machineSets).To(BeEmpty(), "Unexpected machine sets deleted: %#v", t.machineSets)
+	})
 }

--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -111,7 +111,7 @@ func (ac *awsCloud) createClusterSGRule(ctx context.Context, srcGroup, destGroup
 }
 
 func (ac *awsCloud) allowPortInCluster(ctx context.Context, vpcID string, port uint16, protocol string) error {
-	var workerGroupID, controlPlaneGroupID *string
+	var workerGroupID *string
 	var err error
 
 	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
@@ -129,12 +129,10 @@ func (ac *awsCloud) allowPortInCluster(ctx context.Context, vpcID string, port u
 		}
 	}
 
-	if id, exists := ac.cloudConfig[ControlPlaneSecurityGroupIDKey]; exists {
-		if controlPlaneGroupIDStr, ok := id.(string); ok && controlPlaneGroupIDStr != "" {
-			controlPlaneGroupID = &controlPlaneGroupIDStr
-		} else {
-			return errors.New("Control Plane Security Group ID must be a valid non-empty string")
-		}
+	var controlPlaneGroupID *string
+
+	if ac.controlPlaneGroupID != "" {
+		controlPlaneGroupID = &ac.controlPlaneGroupID
 	} else {
 		controlPlaneGroupName := withInfraIDPrefix(ac.controlPlaneSGSuffix)
 
@@ -280,22 +278,14 @@ func (ac *awsCloud) revokePortsInCluster(ctx context.Context, vpcID string) erro
 		}
 	}
 
-	if id, exists := ac.cloudConfig[ControlPlaneSecurityGroupIDKey]; exists {
-		if controlPlaneGroupIDStr, ok := id.(string); ok && controlPlaneGroupIDStr != "" {
-			controlPlaneGroup, err = ac.getSecurityGroupByID(ctx, controlPlaneGroupIDStr)
-			if err != nil {
-				return errors.Wrap(err, "unable to get Control Plane Security Group by ID")
-			}
-		} else {
-			return errors.New("Control Plane Security Group ID must be a valid non-empty string")
-		}
+	if ac.controlPlaneGroupID != "" {
+		controlPlaneGroup, err = ac.getSecurityGroupByID(ctx, ac.controlPlaneGroupID)
 	} else {
-		controlPlaneGroupName := withInfraIDPrefix(ac.controlPlaneSGSuffix)
+		controlPlaneGroup, err = ac.getSecurityGroup(ctx, vpcID, withInfraIDPrefix(ac.controlPlaneSGSuffix))
+	}
 
-		controlPlaneGroup, err = ac.getSecurityGroup(ctx, vpcID, controlPlaneGroupName)
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return errors.Wrap(err, "unable to get Control Plane Security Group")
 	}
 
 	err = ac.revokePortsFromGroup(ctx, &workerGroup)

--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -34,13 +34,23 @@ import (
 
 const internalTraffic = "Internal Submariner traffic"
 
-func (ac *awsCloud) getSecurityGroupName(ctx context.Context, vpcID, name string) (*string, error) {
+func (ac *awsCloud) getSecurityGroupID(ctx context.Context, vpcID, name string) (*string, error) {
 	group, err := ac.getSecurityGroup(ctx, vpcID, name)
 	if err != nil {
 		return nil, err
 	}
 
 	return group.GroupId, nil
+}
+
+func (ac *awsCloud) getWorkerSecurityGroupID(ctx context.Context, vpcID string) (*string, error) {
+	if ac.workerGroupID != "" {
+		return &ac.workerGroupID, nil
+	}
+
+	groupID, err := ac.getSecurityGroupID(ctx, vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
+
+	return groupID, errors.Wrap(err, "unable to get Worker Security Group")
 }
 
 func (ac *awsCloud) getSecurityGroupByID(ctx context.Context, groupID string) (types.SecurityGroup, error) {
@@ -111,22 +121,9 @@ func (ac *awsCloud) createClusterSGRule(ctx context.Context, srcGroup, destGroup
 }
 
 func (ac *awsCloud) allowPortInCluster(ctx context.Context, vpcID string, port uint16, protocol string) error {
-	var workerGroupID *string
-	var err error
-
-	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
-		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
-			workerGroupID = &workerGroupIDStr
-		} else {
-			return errors.New("Worker Security Group ID must be a valid non-empty string")
-		}
-	} else {
-		workerGroupName := withInfraIDPrefix(ac.nodeSGSuffix)
-
-		workerGroupID, err = ac.getSecurityGroupName(ctx, vpcID, workerGroupName)
-		if err != nil {
-			return err
-		}
+	workerGroupID, err := ac.getWorkerSecurityGroupID(ctx, vpcID)
+	if err != nil {
+		return err
 	}
 
 	var controlPlaneGroupID *string
@@ -136,7 +133,7 @@ func (ac *awsCloud) allowPortInCluster(ctx context.Context, vpcID string, port u
 	} else {
 		controlPlaneGroupName := withInfraIDPrefix(ac.controlPlaneSGSuffix)
 
-		controlPlaneGroupID, err = ac.getSecurityGroupName(ctx, vpcID, controlPlaneGroupName)
+		controlPlaneGroupID, err = ac.getSecurityGroupID(ctx, vpcID, controlPlaneGroupName)
 		if err != nil {
 			return err
 		}
@@ -178,7 +175,7 @@ func (ac *awsCloud) createPublicSGRule(ctx context.Context, groupID *string, por
 func (ac *awsCloud) createGatewaySG(ctx context.Context, vpcID string, ports []api.PortSpec) (string, error) {
 	groupName := ac.withAWSInfo(withInfraIDPrefix("-submariner-gw-sg"))
 
-	gatewayGroupID, err := ac.getSecurityGroupName(ctx, vpcID, groupName)
+	gatewayGroupID, err := ac.getSecurityGroupID(ctx, vpcID, groupName)
 	if err != nil {
 		if !isNotFoundError(err) {
 			return "", err
@@ -225,7 +222,7 @@ func gatewayDeletionRetriable(err error) bool {
 func (ac *awsCloud) deleteGatewaySG(ctx context.Context, vpcID string) error {
 	groupName := ac.withAWSInfo(withInfraIDPrefix("-submariner-gw-sg"))
 
-	gatewayGroupID, err := ac.getSecurityGroupName(ctx, vpcID, groupName)
+	gatewayGroupID, err := ac.getSecurityGroupID(ctx, vpcID, groupName)
 	if err != nil {
 		if isNotFoundError(err) {
 			return nil
@@ -260,22 +257,14 @@ func (ac *awsCloud) revokePortsInCluster(ctx context.Context, vpcID string) erro
 	var workerGroup, controlPlaneGroup types.SecurityGroup
 	var err error
 
-	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
-		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
-			workerGroup, err = ac.getSecurityGroupByID(ctx, workerGroupIDStr)
-			if err != nil {
-				return errors.Wrap(err, "unable to get Worker Security Group by ID")
-			}
-		} else {
-			return errors.New("Worker Security Group ID must be a valid non-empty string")
-		}
+	if ac.workerGroupID != "" {
+		workerGroup, err = ac.getSecurityGroupByID(ctx, ac.workerGroupID)
 	} else {
-		workerGroupName := withInfraIDPrefix(ac.nodeSGSuffix)
+		workerGroup, err = ac.getSecurityGroup(ctx, vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
+	}
 
-		workerGroup, err = ac.getSecurityGroup(ctx, vpcID, workerGroupName)
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return errors.Wrap(err, "unable to get Worker Security Group")
 	}
 
 	if ac.controlPlaneGroupID != "" {

--- a/pkg/aws/subnets.go
+++ b/pkg/aws/subnets.go
@@ -54,7 +54,7 @@ func subnetTagged(subnet *types.Subnet) bool {
 	return hasTag(subnet.Tags, tagSubmarinerGateway)
 }
 
-func (ac *awsCloud) findPublicSubnets(ctx context.Context, vpcID string, filter types.Filter) ([]types.Subnet, error) {
+func (ac *awsCloud) findSubnetsByFilter(ctx context.Context, vpcID string, filter types.Filter) ([]types.Subnet, error) {
 	ownedFilters := ac.filterByCurrentCluster()
 	var err error
 	var result *ec2.DescribeSubnetsOutput
@@ -79,6 +79,26 @@ func (ac *awsCloud) findPublicSubnets(ctx context.Context, vpcID string, filter 
 	return result.Subnets, nil
 }
 
+func (ac *awsCloud) findPublicSubnets(ctx context.Context, vpcID string, filter types.Filter) ([]types.Subnet, error) {
+	if len(ac.publicSubnetList) == 0 {
+		publicSubnets, err := ac.findSubnetsByFilter(ctx, vpcID, filter)
+		return publicSubnets, errors.Wrap(err, "unable to find public subnets")
+	}
+
+	var publicSubnets []types.Subnet
+
+	for _, id := range ac.publicSubnetList {
+		subnet, err := ac.getSubnetByID(ctx, id)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to find subnet with ID %q", id)
+		}
+
+		publicSubnets = append(publicSubnets, *subnet)
+	}
+
+	return publicSubnets, nil
+}
+
 func (ac *awsCloud) getSubnetsSupportingInstanceType(ctx context.Context, subnets []types.Subnet,
 	instanceType string,
 ) ([]types.Subnet, error) {
@@ -96,10 +116,6 @@ func (ac *awsCloud) getSubnetsSupportingInstanceType(ctx context.Context, subnet
 
 		return len(output.InstanceTypeOfferings) > 0, nil
 	})
-}
-
-func (ac *awsCloud) getTaggedPublicSubnets(ctx context.Context, vpcID string) ([]types.Subnet, error) {
-	return ac.findPublicSubnets(ctx, vpcID, ec2FilterByTag(tagSubmarinerGateway))
 }
 
 func (ac *awsCloud) tagPublicSubnet(ctx context.Context, subnetID *string) error {
@@ -139,4 +155,12 @@ func (ac *awsCloud) getSubnetByID(ctx context.Context, subnetID string) (*types.
 	}
 
 	return &output.Subnets[0], nil
+}
+
+func (ac *awsCloud) publicFilter() types.Filter {
+	return ac.filterByName("{infraID}*-public-{region}*")
+}
+
+func submarinerGatewayFilter() types.Filter {
+	return ec2FilterByTag(tagSubmarinerGateway)
 }

--- a/pkg/aws/validations.go
+++ b/pkg/aws/validations.go
@@ -54,21 +54,9 @@ func (ac *awsCloud) validateCreateSecGroup(ctx context.Context, vpcID string) er
 }
 
 func (ac *awsCloud) validateCreateSecGroupRule(ctx context.Context, vpcID string) error {
-	var workerGroupID *string
-
-	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
-		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
-			workerGroupID = &workerGroupIDStr
-		} else {
-			return errors.New("Worker Security Group ID must be a valid non-empty string")
-		}
-	} else {
-		var err error
-
-		workerGroupID, err = ac.getSecurityGroupName(ctx, vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
-		if err != nil {
-			return err
-		}
+	workerGroupID, err := ac.getWorkerSecurityGroupID(ctx, vpcID)
+	if err != nil {
+		return err
 	}
 
 	input := &ec2.AuthorizeSecurityGroupIngressInput{
@@ -76,7 +64,7 @@ func (ac *awsCloud) validateCreateSecGroupRule(ctx context.Context, vpcID string
 		GroupId: workerGroupID,
 	}
 
-	_, err := ac.client.AuthorizeSecurityGroupIngress(ctx, input)
+	_, err = ac.client.AuthorizeSecurityGroupIngress(ctx, input)
 
 	return determinePermissionError(err, "authorize security group ingress")
 }
@@ -102,21 +90,9 @@ func (ac *awsCloud) validateDescribeInstanceTypeOfferings(ctx context.Context) e
 }
 
 func (ac *awsCloud) validateDeleteSecGroup(ctx context.Context, vpcID string) error {
-	var workerGroupID *string
-
-	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
-		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
-			workerGroupID = &workerGroupIDStr
-		} else {
-			return errors.New("Worker Security Group ID must be a valid non-empty string")
-		}
-	} else {
-		var err error
-
-		workerGroupID, err = ac.getSecurityGroupName(ctx, vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
-		if err != nil {
-			return err
-		}
+	workerGroupID, err := ac.getWorkerSecurityGroupID(ctx, vpcID)
+	if err != nil {
+		return err
 	}
 
 	input := &ec2.DeleteSecurityGroupInput{
@@ -124,27 +100,15 @@ func (ac *awsCloud) validateDeleteSecGroup(ctx context.Context, vpcID string) er
 		GroupId: workerGroupID,
 	}
 
-	_, err := ac.client.DeleteSecurityGroup(ctx, input)
+	_, err = ac.client.DeleteSecurityGroup(ctx, input)
 
 	return determinePermissionError(err, "delete security group")
 }
 
 func (ac *awsCloud) validateDeleteSecGroupRule(ctx context.Context, vpcID string) error {
-	var workerGroupID *string
-
-	if id, exists := ac.cloudConfig[WorkerSecurityGroupIDKey]; exists {
-		if workerGroupIDStr, ok := id.(string); ok && workerGroupIDStr != "" {
-			workerGroupID = &workerGroupIDStr
-		} else {
-			return errors.New("Worker Security Group ID must be a valid non-empty string")
-		}
-	} else {
-		var err error
-
-		workerGroupID, err = ac.getSecurityGroupName(ctx, vpcID, withInfraIDPrefix(ac.nodeSGSuffix))
-		if err != nil {
-			return err
-		}
+	workerGroupID, err := ac.getWorkerSecurityGroupID(ctx, vpcID)
+	if err != nil {
+		return err
 	}
 
 	input := &ec2.RevokeSecurityGroupIngressInput{
@@ -152,7 +116,7 @@ func (ac *awsCloud) validateDeleteSecGroupRule(ctx context.Context, vpcID string
 		GroupId: workerGroupID,
 	}
 
-	_, err := ac.client.RevokeSecurityGroupIngress(ctx, input)
+	_, err = ac.client.RevokeSecurityGroupIngress(ctx, input)
 
 	return determinePermissionError(err, "revoke security group ingress")
 }

--- a/pkg/aws/vpcs.go
+++ b/pkg/aws/vpcs.go
@@ -30,13 +30,8 @@ func (ac *awsCloud) getVpcID(ctx context.Context) (string, error) {
 	var err error
 	var result *ec2.DescribeVpcsOutput
 
-	if vpcID, exists := ac.cloudConfig[VPCIDKey]; exists {
-		vpcIDStr, ok := vpcID.(string)
-		if !ok || vpcIDStr == "" {
-			return "", errors.New("VPC ID needs to be a valid non-empty string")
-		}
-
-		return vpcIDStr, nil
+	if ac.vpcID != "" {
+		return ac.vpcID, nil
 	}
 
 	ownedFilters := ac.filterByCurrentCluster()


### PR DESCRIPTION
The user-configurable options were stored in the internal `cloudConfig` map however this complicates access, requiring type casting. We can simplify access by moving these to explicit fields.

Also added unit tests to cover all the options. **Note**: the test case on line 125 in _aws_cloud_test.go_ is set to pending because it currently fails however it requires investigation outside the scope of this PR. A separate [issue](https://github.com/submariner-io/cloud-prepare/issues/1278) was created to address it.

See commits for details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud creation accepts optional configuration options (including explicit VPC and subnet IDs) for more flexible setup.

* **Refactor**
  * Replaced map-based config with explicit cached fields for VPC, subnets and security groups.
  * Lookups switched to ID-first flows with unified subnet discovery and simplified error handling.

* **Tests**
  * Expanded and restructured tests to cover new option-driven paths and ID-based behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->