### PR TITLE
Use Ginkgo context instead of context.TODO

### DIFF
--- a/pkg/aws/aws_cloud_test.go
+++ b/pkg/aws/aws_cloud_test.go
@@ -46,8 +46,8 @@ func testOpenPorts() {
 		t.expectDescribeSecurityGroups(t.workerSGName, t.workerGroupID)
 	})
 
-	doOpenPorts := func() error {
-		return t.cloud.OpenPorts(context.TODO(), []api.PortSpec{
+	doOpenPorts := func(ctx context.Context) error {
+		return t.cloud.OpenPorts(ctx, []api.PortSpec{
 			{
 				Port:     100,
 				Protocol: "TCP",
@@ -73,8 +73,8 @@ func testOpenPorts() {
 			t.expectAuthorizeSecurityGroupIngress(t.masterGroupID, newClusterSGRule(t.workerGroupID, 200, "UDP"))
 		})
 
-		It("should authorize the appropriate security groups ingress", func() {
-			Expect(doOpenPorts()).To(Succeed())
+		It("should authorize the appropriate security groups ingress", func(ctx SpecContext) {
+			Expect(doOpenPorts(ctx)).To(Succeed())
 		})
 
 		Context("WithWorkerSecurityGroup", func() {
@@ -83,8 +83,8 @@ func testOpenPorts() {
 				t.cloudOptions = append(t.cloudOptions, aws.WithWorkerSecurityGroup(t.workerGroupID))
 			})
 
-			It("should authorize the appropriate security groups ingress", func() {
-				Expect(doOpenPorts()).To(Succeed())
+			It("should authorize the appropriate security groups ingress", func(ctx SpecContext) {
+				Expect(doOpenPorts(ctx)).To(Succeed())
 			})
 		})
 
@@ -94,8 +94,8 @@ func testOpenPorts() {
 				t.cloudOptions = append(t.cloudOptions, aws.WithControlPlaneSecurityGroup(t.masterGroupID))
 			})
 
-			It("should authorize the appropriate security groups ingress", func() {
-				Expect(doOpenPorts()).To(Succeed())
+			It("should authorize the appropriate security groups ingress", func(ctx SpecContext) {
+				Expect(doOpenPorts(ctx)).To(Succeed())
 			})
 		})
 
@@ -117,8 +117,8 @@ func testOpenPorts() {
 				})
 			})
 
-			It("should authorize the appropriate security groups ingress", func() {
-				Expect(doOpenPorts()).To(Succeed())
+			It("should authorize the appropriate security groups ingress", func(ctx SpecContext) {
+				Expect(doOpenPorts(ctx)).To(Succeed())
 			})
 		})
 
@@ -131,8 +131,8 @@ func testOpenPorts() {
 				t.cloudOptions = append(t.cloudOptions, aws.WithVPCName(t.vpcID))
 			})
 
-			It("should authorize the appropriate security groups ingress", func() {
-				Expect(doOpenPorts()).To(Succeed())
+			It("should authorize the appropriate security groups ingress", func(ctx SpecContext) {
+				Expect(doOpenPorts(ctx)).To(Succeed())
 			})
 		})
 	})
@@ -142,8 +142,8 @@ func testOpenPorts() {
 			t.existingVpcs = []types.Vpc{}
 		})
 
-		It("should return an error", func() {
-			Expect(doOpenPorts()).To(HaveOccurred())
+		It("should return an error", func(ctx SpecContext) {
+			Expect(doOpenPorts(ctx)).To(HaveOccurred())
 		})
 	})
 
@@ -153,8 +153,8 @@ func testOpenPorts() {
 			t.expectValidateAuthorizeSecurityGroupIngress(errors.New("mock error"))
 		})
 
-		It("should return an error", func() {
-			Expect(doOpenPorts()).To(HaveOccurred())
+		It("should return an error", func(ctx SpecContext) {
+			Expect(doOpenPorts(ctx)).To(HaveOccurred())
 		})
 	})
 
@@ -164,8 +164,8 @@ func testOpenPorts() {
 			t.expectDescribeSecurityGroupsFailure(t.masterSGName, errors.New("mock error"))
 		})
 
-		It("should return an error", func() {
-			Expect(doOpenPorts()).To(HaveOccurred())
+		It("should return an error", func(ctx SpecContext) {
+			Expect(doOpenPorts(ctx)).To(HaveOccurred())
 		})
 	})
 }
@@ -183,8 +183,8 @@ func testClosePorts() {
 		t.expectDescribeSecurityGroups(t.workerSGName, t.workerGroupID, ipPerm)
 	})
 
-	doClosePorts := func() error {
-		return t.cloud.ClosePorts(context.TODO(), reporter.Stdout())
+	doClosePorts := func(ctx context.Context) error {
+		return t.cloud.ClosePorts(ctx, reporter.Stdout())
 	}
 
 	Context("on success", func() {
@@ -198,8 +198,8 @@ func testClosePorts() {
 			t.expectRevokeSecurityGroupIngress(t.workerGroupID, ipPerm)
 		})
 
-		It("should revoke the appropriate security groups ingress", func() {
-			Expect(doClosePorts()).To(Succeed())
+		It("should revoke the appropriate security groups ingress", func(ctx SpecContext) {
+			Expect(doClosePorts(ctx)).To(Succeed())
 		})
 
 		Context("WithWorkerSecurityGroup", func() {
@@ -210,8 +210,8 @@ func testClosePorts() {
 				t.expectDescribeSecurityGroupsByID(t.workerGroupID, ipPerm)
 			})
 
-			It("should revoke the appropriate security groups ingress", func() {
-				Expect(doClosePorts()).To(Succeed())
+			It("should revoke the appropriate security groups ingress", func(ctx SpecContext) {
+				Expect(doClosePorts(ctx)).To(Succeed())
 			})
 		})
 
@@ -223,8 +223,8 @@ func testClosePorts() {
 				t.expectDescribeSecurityGroupsByID(t.masterGroupID, ipPerm)
 			})
 
-			It("should revoke the appropriate security groups ingress", func() {
-				Expect(doClosePorts()).To(Succeed())
+			It("should revoke the appropriate security groups ingress", func(ctx SpecContext) {
+				Expect(doClosePorts(ctx)).To(Succeed())
 			})
 		})
 	})
@@ -234,8 +234,8 @@ func testClosePorts() {
 			t.existingVpcs = []types.Vpc{}
 		})
 
-		It("should return an error", func() {
-			Expect(doClosePorts()).To(HaveOccurred())
+		It("should return an error", func(ctx SpecContext) {
+			Expect(doClosePorts(ctx)).To(HaveOccurred())
 		})
 	})
 
@@ -244,8 +244,8 @@ func testClosePorts() {
 			t.expectValidateRevokeSecurityGroupIngress(errors.New("mock error"))
 		})
 
-		It("should return an error", func() {
-			Expect(doClosePorts()).To(HaveOccurred())
+		It("should return an error", func(ctx SpecContext) {
+			Expect(doClosePorts(ctx)).To(HaveOccurred())
 		})
 	})
 
@@ -255,8 +255,8 @@ func testClosePorts() {
 			t.expectDescribeSecurityGroupsFailure(t.masterSGName, errors.New("mock error"))
 		})
 
-		It("should return an error", func() {
-			Expect(doClosePorts()).To(HaveOccurred())
+		It("should return an error", func(ctx SpecContext) {
+			Expect(doClosePorts(ctx)).To(HaveOccurred())
 		})
 	})
 }

--- a/pkg/aws/client/client_test.go
+++ b/pkg/aws/client/client_test.go
@@ -37,17 +37,17 @@ const (
 )
 
 var _ = Describe("New", func() {
-	It("should return a valid client", func() {
-		c, err := client.New(context.TODO(), testRegion)
+	It("should return a valid client", func(ctx SpecContext) {
+		c, err := client.New(ctx, testRegion)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(assertEC2Client(c).Options().Region).To(Equal(testRegion))
 	})
 
 	Context("WithCredentials", func() {
-		It("should obtain the credentials directly from the values provided", func() {
-			c, err := client.New(context.TODO(), testRegion, client.WithCredentials(testAccessKeyID, testSecretAccessKey))
+		It("should obtain the credentials directly from the values provided", func(ctx SpecContext) {
+			c, err := client.New(ctx, testRegion, client.WithCredentials(testAccessKeyID, testSecretAccessKey))
 			Expect(err).NotTo(HaveOccurred())
-			assertCredentials(assertEC2Client(c))
+			assertCredentials(ctx, assertEC2Client(c))
 		})
 	})
 
@@ -66,11 +66,12 @@ var _ = Describe("New", func() {
 				_ = os.Setenv("AWS_SHARED_CREDENTIALS_FILE", createCredentialsFile(testProfileName))
 			})
 
-			It("should obtain the credentials defined for the provided profile defined from the default credentials file", func() {
-				c, err := client.New(context.TODO(), testRegion, client.WithConfigProfile(testProfileName))
-				Expect(err).NotTo(HaveOccurred())
-				assertCredentials(assertEC2Client(c))
-			})
+			It("should obtain the credentials defined for the provided profile defined from the default credentials file",
+				func(ctx SpecContext) {
+					c, err := client.New(ctx, testRegion, client.WithConfigProfile(testProfileName))
+					Expect(err).NotTo(HaveOccurred())
+					assertCredentials(ctx, assertEC2Client(c))
+				})
 		})
 
 		Context("and WithCredentialsFile", func() {
@@ -80,12 +81,13 @@ var _ = Describe("New", func() {
 				credentialsFile = createCredentialsFile(testProfileName)
 			})
 
-			It("should obtain the credentials defined for the provided profile from the provided credentials file", func() {
-				c, err := client.New(context.TODO(), testRegion, client.WithConfigProfile(testProfileName),
-					client.WithCredentialsFile(credentialsFile))
-				Expect(err).NotTo(HaveOccurred())
-				assertCredentials(assertEC2Client(c))
-			})
+			It("should obtain the credentials defined for the provided profile from the provided credentials file",
+				func(ctx SpecContext) {
+					c, err := client.New(ctx, testRegion, client.WithConfigProfile(testProfileName),
+						client.WithCredentialsFile(credentialsFile))
+					Expect(err).NotTo(HaveOccurred())
+					assertCredentials(ctx, assertEC2Client(c))
+				})
 		})
 	})
 
@@ -96,16 +98,17 @@ var _ = Describe("New", func() {
 			credentialsFile = createCredentialsFile(client.DefaultProfile())
 		})
 
-		It("should obtain the credentials defined for the default profile from the provided credentials file", func() {
-			c, err := client.New(context.TODO(), testRegion, client.WithCredentialsFile(credentialsFile))
-			Expect(err).NotTo(HaveOccurred())
-			assertCredentials(assertEC2Client(c))
-		})
+		It("should obtain the credentials defined for the default profile from the provided credentials file",
+			func(ctx SpecContext) {
+				c, err := client.New(ctx, testRegion, client.WithCredentialsFile(credentialsFile))
+				Expect(err).NotTo(HaveOccurred())
+				assertCredentials(ctx, assertEC2Client(c))
+			})
 	})
 
 	Context("with a non-existent profile", func() {
-		It("should return an error", func() {
-			_, err := client.New(context.TODO(), testRegion, client.WithConfigProfile("non-existent"))
+		It("should return an error", func(ctx SpecContext) {
+			_, err := client.New(ctx, testRegion, client.WithConfigProfile("non-existent"))
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -118,10 +121,10 @@ func assertEC2Client(c client.Interface) *ec2.Client {
 	return c.(*ec2.Client)
 }
 
-func assertCredentials(c *ec2.Client) {
+func assertCredentials(ctx context.Context, c *ec2.Client) {
 	provider := c.Options().Credentials
 	Expect(provider).NotTo(BeNil())
-	creds, err := provider.Retrieve(context.TODO())
+	creds, err := provider.Retrieve(ctx)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(creds.AccessKeyID).To(Equal(testAccessKeyID))
 	Expect(creds.SecretAccessKey).To(Equal(testSecretAccessKey))

--- a/pkg/aws/ocpgwdeployer_test.go
+++ b/pkg/aws/ocpgwdeployer_test.go
@@ -165,8 +165,8 @@ func testDeploy() {
 				t.existingVpcs = []types.Vpc{}
 			})
 
-			It("should return an error", func() {
-				Expect(t.doDeploy()).To(HaveOccurred())
+			It("should return an error", func(ctx SpecContext) {
+				Expect(t.doDeploy(ctx)).To(HaveOccurred())
 			})
 		})
 
@@ -175,8 +175,8 @@ func testDeploy() {
 				t.describeSubnetsErr = errors.New("mock error")
 			})
 
-			It("should return an error", func() {
-				Expect(t.doDeploy()).To(HaveOccurred())
+			It("should return an error", func(ctx SpecContext) {
+				Expect(t.doDeploy(ctx)).To(HaveOccurred())
 			})
 		})
 
@@ -191,8 +191,8 @@ func testDeploy() {
 				t.expectCreateGatewayTags(*t.expectedSubnetsTagged[0].SubnetId)
 			})
 
-			It("should return an error", func() {
-				Expect(t.doDeploy()).To(HaveOccurred())
+			It("should return an error", func(ctx SpecContext) {
+				Expect(t.doDeploy(ctx)).To(HaveOccurred())
 			})
 		})
 
@@ -202,8 +202,8 @@ func testDeploy() {
 				t.expectAuthorizeSecurityGroupIngress(gatewayGroupID, newPublicSGRule(100, "TCP"))
 			})
 
-			It("should return an error", func() {
-				Expect(t.doDeploy()).To(HaveOccurred())
+			It("should return an error", func(ctx SpecContext) {
+				Expect(t.doDeploy(ctx)).To(HaveOccurred())
 			})
 		})
 
@@ -212,8 +212,8 @@ func testDeploy() {
 				t.existingSubnets = []types.Subnet{}
 			})
 
-			It("should return an error", func() {
-				Expect(t.doDeploy()).To(HaveOccurred())
+			It("should return an error", func(ctx SpecContext) {
+				Expect(t.doDeploy(ctx)).To(HaveOccurred())
 			})
 		})
 	})
@@ -262,8 +262,8 @@ func testCleanup() {
 				t.existingVpcs = []types.Vpc{}
 			})
 
-			It("should return an error", func() {
-				Expect(t.doCleanup()).To(HaveOccurred())
+			It("should return an error", func(ctx SpecContext) {
+				Expect(t.doCleanup(ctx)).To(HaveOccurred())
 			})
 		})
 
@@ -272,8 +272,8 @@ func testCleanup() {
 				t.describeSubnetsErr = errors.New("mock error")
 			})
 
-			It("should return an error", func() {
-				Expect(t.doCleanup()).To(HaveOccurred())
+			It("should return an error", func(ctx SpecContext) {
+				Expect(t.doCleanup(ctx)).To(HaveOccurred())
 			})
 		})
 	})
@@ -351,8 +351,8 @@ func (t *gatewayDeployerTestDriver) expectedInstanceType() string {
 	return aws.PreferredInstances[0]
 }
 
-func (t *gatewayDeployerTestDriver) doDeploy() error {
-	return t.gwDeployer.Deploy(context.TODO(), api.GatewayDeployInput{
+func (t *gatewayDeployerTestDriver) doDeploy(ctx context.Context) error {
+	return t.gwDeployer.Deploy(ctx, api.GatewayDeployInput{
 		Gateways: t.numGateways,
 		PublicPorts: []api.PortSpec{
 			{
@@ -367,8 +367,8 @@ func (t *gatewayDeployerTestDriver) doDeploy() error {
 	}, reporter.Stdout())
 }
 
-func (t *gatewayDeployerTestDriver) doCleanup() error {
-	return t.gwDeployer.Cleanup(context.TODO(), reporter.Stdout())
+func (t *gatewayDeployerTestDriver) doCleanup(ctx context.Context) error {
+	return t.gwDeployer.Cleanup(ctx, reporter.Stdout())
 }
 
 func (t *gatewayDeployerTestDriver) expectDeployValidations(enforce bool) {
@@ -407,8 +407,8 @@ func (t *gatewayDeployerTestDriver) testDeploySuccess(msgPrefix, msgSuffix strin
 		msg = "should"
 	}
 
-	It(msg+" deploy the correct gateway node machine sets"+msgSuffix, func() {
-		Expect(t.doDeploy()).To(Succeed())
+	It(msg+" deploy the correct gateway node machine sets"+msgSuffix, func(ctx SpecContext) {
+		Expect(t.doDeploy(ctx)).To(Succeed())
 
 		for i := range t.expectedSubnetsDeployed {
 			t.assertMachineSet(t.machineSets[*t.expectedSubnetsDeployed[i].AvailabilityZone], *t.expectedSubnetsDeployed[i].SubnetId,
@@ -484,8 +484,8 @@ func (t *gatewayDeployerTestDriver) setupExpectedSubnetInstanceTypeOfferings(sub
 }
 
 func (t *gatewayDeployerTestDriver) testCleanupSuccess() {
-	It("should delete the correct gateway node machine sets", func() {
-		Expect(t.doCleanup()).To(Succeed())
+	It("should delete the correct gateway node machine sets", func(ctx SpecContext) {
+		Expect(t.doCleanup(ctx)).To(Succeed())
 
 		for i := range t.existingSubnets {
 			subnet := &t.existingSubnets[i]

--- a/pkg/azure/azure_cloud_test.go
+++ b/pkg/azure/azure_cloud_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package azure_test
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v8"
@@ -44,7 +43,7 @@ var _ = Describe("Cloud", func() {
 		}
 	})
 
-	Specify("should open and close ports correctly", func() {
+	Specify("should open and close ports correctly", func(ctx SpecContext) {
 		cloud := azure.NewCloud(&t.cloudInfo)
 
 		port := api.PortSpec{
@@ -52,7 +51,7 @@ var _ = Describe("Cloud", func() {
 			Protocol: string(armnetwork.SecurityRuleProtocolTCP),
 		}
 
-		Expect(cloud.OpenPorts(context.TODO(), []api.PortSpec{port}, reporter.Stdout())).To(Succeed())
+		Expect(cloud.OpenPorts(ctx, []api.PortSpec{port}, reporter.Stdout())).To(Succeed())
 
 		var securityGroup armnetwork.SecurityGroup
 		t.assertPutRequest(internalSecurityGroupPath, &securityGroup)
@@ -65,7 +64,7 @@ var _ = Describe("Cloud", func() {
 
 		t.httpGetResponses[internalSecurityGroupPath] = &securityGroup
 
-		Expect(cloud.OpenPorts(context.TODO(), []api.PortSpec{port}, reporter.Stdout())).To(Succeed())
+		Expect(cloud.OpenPorts(ctx, []api.PortSpec{port}, reporter.Stdout())).To(Succeed())
 		t.assertNoPutRequest(internalSecurityGroupPath)
 
 		By("Close ports")
@@ -75,7 +74,7 @@ var _ = Describe("Cloud", func() {
 		}
 		securityGroup.Properties.SecurityRules = append(securityGroup.Properties.SecurityRules, otherRule)
 
-		Expect(cloud.ClosePorts(context.TODO(), reporter.Stdout())).To(Succeed())
+		Expect(cloud.ClosePorts(ctx, reporter.Stdout())).To(Succeed())
 		t.assertPutRequest(internalSecurityGroupPath, &securityGroup)
 		Expect(securityGroup.Properties.SecurityRules).To(ConsistOf(Satisfy(func(r *armnetwork.SecurityRule) bool {
 			return ptr.Deref(r.Name, "") == *otherRule.Name
@@ -83,21 +82,21 @@ var _ = Describe("Cloud", func() {
 	})
 
 	When("security group retrieval fails", func() {
-		Specify("OpenPorts should return an error", func() {
+		Specify("OpenPorts should return an error", func(ctx SpecContext) {
 			t.httpGetResponses[internalSecurityGroupPath] = http.StatusUnauthorized
 
 			cloud := azure.NewCloud(&t.cloudInfo)
-			Expect(cloud.OpenPorts(context.TODO(), []api.PortSpec{{Port: 80, Protocol: string(armnetwork.SecurityRuleProtocolTCP)}},
+			Expect(cloud.OpenPorts(ctx, []api.PortSpec{{Port: 80, Protocol: string(armnetwork.SecurityRuleProtocolTCP)}},
 				reporter.Stdout())).NotTo(Succeed())
 		})
 	})
 
 	When("security group creation fails", func() {
-		Specify("OpenPorts should return an error", func() {
+		Specify("OpenPorts should return an error", func(ctx SpecContext) {
 			t.httpPutRespCodes[internalSecurityGroupPath] = ptr.To(http.StatusUnauthorized)
 
 			cloud := azure.NewCloud(&t.cloudInfo)
-			Expect(cloud.OpenPorts(context.TODO(), []api.PortSpec{{Port: 80, Protocol: string(armnetwork.SecurityRuleProtocolTCP)}},
+			Expect(cloud.OpenPorts(ctx, []api.PortSpec{{Port: 80, Protocol: string(armnetwork.SecurityRuleProtocolTCP)}},
 				reporter.Stdout())).NotTo(Succeed())
 		})
 	})

--- a/pkg/azure/ocpgwdeployer_test.go
+++ b/pkg/azure/ocpgwdeployer_test.go
@@ -129,7 +129,7 @@ func testDeploy() {
 			}
 		})
 
-		It("should deploy gateway machine sets and external port security group rules", func() {
+		It("should deploy gateway machine sets and external port security group rules", func(ctx SpecContext) {
 			input := api.GatewayDeployInput{
 				Gateways: 2,
 				PublicPorts: []api.PortSpec{
@@ -143,7 +143,7 @@ func testDeploy() {
 					},
 				},
 			}
-			Expect(t.deployer.Deploy(context.TODO(), input, reporter.Stdout())).To(Succeed())
+			Expect(t.deployer.Deploy(ctx, input, reporter.Stdout())).To(Succeed())
 
 			t.assertMachineSets(false, 2, "zone1", "zone2", "zone3")
 
@@ -162,8 +162,8 @@ func testDeploy() {
 				}
 			})
 
-			It("should not try to recreate it", func() {
-				Expect(t.deployer.Deploy(context.TODO(), api.GatewayDeployInput{
+			It("should not try to recreate it", func(ctx SpecContext) {
+				Expect(t.deployer.Deploy(ctx, api.GatewayDeployInput{
 					Gateways: 1,
 				}, reporter.Stdout())).To(Succeed())
 
@@ -172,8 +172,8 @@ func testDeploy() {
 		})
 
 		Context("with AirGapped specified", func() {
-			It("should deploy gateway machine sets without a public IP", func() {
-				Expect(t.deployer.Deploy(context.TODO(), api.GatewayDeployInput{
+			It("should deploy gateway machine sets without a public IP", func(ctx SpecContext) {
+				Expect(t.deployer.Deploy(ctx, api.GatewayDeployInput{
 					Gateways:  1,
 					AirGapped: true,
 				}, reporter.Stdout())).To(Succeed())
@@ -188,8 +188,8 @@ func testDeploy() {
 			t.existingMachineSets = []unstructured.Unstructured{*t.createMachineSet("existing-gw", "zone1")}
 		})
 
-		It("should not deploy new gateways", func() {
-			Expect(t.deployer.Deploy(context.TODO(), api.GatewayDeployInput{
+		It("should not deploy new gateways", func(ctx SpecContext) {
+			Expect(t.deployer.Deploy(ctx, api.GatewayDeployInput{
 				Gateways: 1,
 			}, reporter.Stdout())).To(Succeed())
 
@@ -217,8 +217,8 @@ func testDeploy() {
 			}
 		})
 
-		It("should deploy new gateways to match the requested count", func() {
-			Expect(t.deployer.Deploy(context.TODO(), api.GatewayDeployInput{
+		It("should deploy new gateways to match the requested count", func(ctx SpecContext) {
+			Expect(t.deployer.Deploy(ctx, api.GatewayDeployInput{
 				Gateways: 2,
 			}, reporter.Stdout())).To(Succeed())
 
@@ -227,9 +227,9 @@ func testDeploy() {
 	})
 
 	When("manually labeled gateway nodes exist", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			for _, name := range []string{nodeName1, nodeName2} {
-				t.createGatewayNode(name)
+				t.createGatewayNode(ctx, name)
 
 				nicName := name + "-nic"
 				t.httpGetResponses[networkInterfacesPath(nicName)] = &armnetwork.Interface{
@@ -247,8 +247,8 @@ func testDeploy() {
 			}
 		})
 
-		It("should prepare the network interface with a public IP for each node", func() {
-			Expect(t.deployer.Deploy(context.TODO(), api.GatewayDeployInput{
+		It("should prepare the network interface with a public IP for each node", func(ctx SpecContext) {
+			Expect(t.deployer.Deploy(ctx, api.GatewayDeployInput{
 				Gateways: 2,
 				PublicPorts: []api.PortSpec{
 					{
@@ -277,12 +277,12 @@ func testDeploy() {
 	})
 
 	When("no gateways are requested", func() {
-		It("should succeed", func() {
+		It("should succeed", func(ctx SpecContext) {
 			input := api.GatewayDeployInput{
 				Gateways: 0,
 			}
 
-			err := t.deployer.Deploy(context.TODO(), input, reporter.Stdout())
+			err := t.deployer.Deploy(ctx, input, reporter.Stdout())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -292,8 +292,8 @@ func testDeploy() {
 			t.httpGetResponses[SKUsPath] = &armcompute.ResourceSKUsResult{}
 		})
 
-		It("should return an error", func() {
-			Expect(t.deployer.Deploy(context.TODO(), api.GatewayDeployInput{
+		It("should return an error", func(ctx SpecContext) {
+			Expect(t.deployer.Deploy(ctx, api.GatewayDeployInput{
 				Gateways: 1,
 			}, reporter.Stdout())).NotTo(Succeed())
 		})
@@ -304,8 +304,8 @@ func testDeploy() {
 			t.httpPutRespCodes[securityGroupPath(extSecurityGroupName)] = ptr.To(http.StatusUnauthorized)
 		})
 
-		It("should return an error", func() {
-			Expect(t.deployer.Deploy(context.TODO(), api.GatewayDeployInput{
+		It("should return an error", func(ctx SpecContext) {
+			Expect(t.deployer.Deploy(ctx, api.GatewayDeployInput{
 				Gateways: 1,
 			}, reporter.Stdout())).NotTo(Succeed())
 		})
@@ -315,10 +315,10 @@ func testDeploy() {
 func testCleanup() {
 	t := newGatewayDeployerTestDriver()
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx SpecContext) {
 		t.existingMachineSets = []unstructured.Unstructured{*t.createMachineSet("existing-ms", "zone1")}
 
-		t.createGatewayNode(nodeName1)
+		t.createGatewayNode(ctx, nodeName1)
 
 		publicIPAddress := &armnetwork.PublicIPAddress{
 			Name: ptr.To(nodeName1 + "-pub"),
@@ -362,14 +362,14 @@ func testCleanup() {
 		}
 	})
 
-	It("should delete the gateway machine sets and perform related cleanup", func() {
-		Expect(t.deployer.Cleanup(context.TODO(), reporter.Stdout())).To(Succeed())
+	It("should delete the gateway machine sets and perform related cleanup", func(ctx SpecContext) {
+		Expect(t.deployer.Cleanup(ctx, reporter.Stdout())).To(Succeed())
 
 		Expect(t.existingMachineSets).To(BeEmpty())
 		Expect(t.httpGetResponses).NotTo(HaveKey(publicAddressesPath(nodeName1 + "-pub")))
 		Expect(t.httpGetResponses).NotTo(HaveKey(securityGroupPath(extSecurityGroupName)))
 
-		node, err := t.kubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName1, metav1.GetOptions{})
+		node, err := t.kubeClient.CoreV1().Nodes().Get(ctx, nodeName1, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(node.Labels).NotTo(HaveKey(k8s.SubmarinerGatewayLabel))
 	})
@@ -445,8 +445,8 @@ func (t *gatewayDeployerTestDriver) assertMachineSets(airGapped bool, count int,
 	Expect(t.machineSetsDeployed).To(HaveLen(count))
 }
 
-func (t *gatewayDeployerTestDriver) createGatewayNode(name string) {
-	_, err := t.kubeClient.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+func (t *gatewayDeployerTestDriver) createGatewayNode(ctx context.Context, name string) {
+	_, err := t.kubeClient.CoreV1().Nodes().Create(ctx, &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: map[string]string{k8s.SubmarinerGatewayLabel: "true"},

--- a/pkg/gcp/gcp_cloud_test.go
+++ b/pkg/gcp/gcp_cloud_test.go
@@ -45,8 +45,8 @@ func testOpenPorts() {
 
 	var retError error
 
-	JustBeforeEach(func() {
-		retError = t.cloud.OpenPorts(context.TODO(), []api.PortSpec{
+	JustBeforeEach(func(ctx SpecContext) {
+		retError = t.cloud.OpenPorts(ctx, []api.PortSpec{
 			{
 				Port:     100,
 				Protocol: "TCP",
@@ -150,8 +150,8 @@ func testClosePorts() {
 
 	var retError error
 
-	JustBeforeEach(func() {
-		retError = t.cloud.ClosePorts(context.TODO(), reporter.Stdout())
+	JustBeforeEach(func(ctx SpecContext) {
+		retError = t.cloud.ClosePorts(ctx, reporter.Stdout())
 	})
 
 	Context("on success", func() {

--- a/pkg/gcp/ocpgwdeployer_test.go
+++ b/pkg/gcp/ocpgwdeployer_test.go
@@ -71,8 +71,8 @@ func testDeploy() {
 			})
 	})
 
-	JustBeforeEach(func() {
-		retError = t.doDeploy()
+	JustBeforeEach(func(ctx SpecContext) {
+		retError = t.doDeploy(ctx)
 	})
 
 	It("should insert the firewall rule", func() {
@@ -92,9 +92,9 @@ func testDeploy() {
 			t.numGateways = 1
 		})
 
-		It("should do nothing", func() {
+		It("should do nothing", func(ctx SpecContext) {
 			Expect(retError).To(Succeed())
-			t.assertLabeledNodes("node-1", "node-2")
+			t.assertLabeledNodes(ctx, "node-1", "node-2")
 		})
 	})
 
@@ -178,9 +178,9 @@ func testCleanup() {
 		deleteFirewallRule = nil
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		t.gcpClient.EXPECT().DeleteFirewallRule(mock.Anything, projectID, publicPortsRuleName).Return(deleteFirewallRule)
-		retError = t.gwDeployer.Cleanup(context.TODO(), reporter.Stdout())
+		retError = t.gwDeployer.Cleanup(ctx, reporter.Stdout())
 	})
 
 	It("should delete the firewall rule", func() {
@@ -201,9 +201,9 @@ func testCleanup() {
 			t.expInstanceUntagged(zone2, t.instances[zone2][0])
 		})
 
-		It("should unlabel them", func() {
+		It("should unlabel them", func(ctx SpecContext) {
 			Expect(retError).To(Succeed())
-			t.assertLabeledNodes()
+			t.assertLabeledNodes(ctx)
 		})
 	})
 
@@ -308,7 +308,7 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 		t.kubeClient = kubeFake.NewClientset()
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		t.gcpClient.EXPECT().ListZones(mock.Anything).Return(&compute.ZoneList{Items: t.zones}, nil).Maybe()
 		t.gcpClient.EXPECT().ListInstances(mock.Anything, mock.Anything).RunAndReturn(
 			func(_ context.Context, zone string) (*compute.InstanceList, error) {
@@ -333,7 +333,7 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 			}).Maybe()
 
 		for _, node := range t.nodes {
-			_, err := t.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+			_, err := t.kubeClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 			Expect(err).To(Succeed())
 		}
 
@@ -350,8 +350,8 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 	return t
 }
 
-func (t *gatewayDeployerTestDriver) doDeploy() error {
-	return t.gwDeployer.Deploy(context.TODO(), api.GatewayDeployInput{
+func (t *gatewayDeployerTestDriver) doDeploy(ctx context.Context) error {
+	return t.gwDeployer.Deploy(ctx, api.GatewayDeployInput{
 		Gateways: t.numGateways,
 		PublicPorts: []api.PortSpec{
 			{
@@ -366,11 +366,11 @@ func (t *gatewayDeployerTestDriver) doDeploy() error {
 	}, reporter.Stdout())
 }
 
-func (t *gatewayDeployerTestDriver) getLabeledNodes() []string {
+func (t *gatewayDeployerTestDriver) getLabeledNodes(ctx context.Context) []string {
 	found := []string{}
 
 	for _, expected := range t.nodes {
-		actual, err := t.kubeClient.CoreV1().Nodes().Get(context.TODO(), expected.Name, metav1.GetOptions{})
+		actual, err := t.kubeClient.CoreV1().Nodes().Get(ctx, expected.Name, metav1.GetOptions{})
 		Expect(err).To(Succeed())
 
 		if actual.Labels["submariner.io/gateway"] == "true" {
@@ -381,8 +381,8 @@ func (t *gatewayDeployerTestDriver) getLabeledNodes() []string {
 	return found
 }
 
-func (t *gatewayDeployerTestDriver) assertLabeledNodes(expNodes ...string) {
-	actual := t.getLabeledNodes()
+func (t *gatewayDeployerTestDriver) assertLabeledNodes(ctx context.Context, expNodes ...string) {
+	actual := t.getLabeledNodes(ctx)
 	Expect(actual).To(HaveLen(len(expNodes)))
 
 	for _, n := range expNodes {

--- a/pkg/k8s/k8siface_test.go
+++ b/pkg/k8s/k8siface_test.go
@@ -32,8 +32,6 @@ import (
 	kubeFake "k8s.io/client-go/kubernetes/fake"
 )
 
-var ctx = context.TODO()
-
 var _ = Describe("Interface", func() {
 	Describe("ListNodesWithLabel", testListNodesWithLabel)
 	Describe("ListGatewayNodes", testListGatewayNodes)
@@ -52,12 +50,12 @@ func testRemoveGWLabelFromWorkerNodes() {
 		}
 	})
 
-	It("should remove the label from all nodes", func() {
+	It("should remove the label from all nodes", func(ctx SpecContext) {
 		Expect(t.client.RemoveGWLabelFromWorkerNodes(ctx)).To(Succeed())
-		t.assertNoLabel(t.nodes[0].Name, k8s.SubmarinerGatewayLabel)
-		t.assertNoLabel(t.nodes[1].Name, k8s.SubmarinerGatewayLabel)
-		t.assertNoLabel(t.nodes[2].Name, k8s.SubmarinerGatewayLabel)
-		t.assertLabel(t.nodes[2].Name, "foo", "bar")
+		t.assertNoLabel(ctx, t.nodes[0].Name, k8s.SubmarinerGatewayLabel)
+		t.assertNoLabel(ctx, t.nodes[1].Name, k8s.SubmarinerGatewayLabel)
+		t.assertNoLabel(ctx, t.nodes[2].Name, k8s.SubmarinerGatewayLabel)
+		t.assertLabel(ctx, t.nodes[2].Name, "foo", "bar")
 	})
 
 	Context("on failure", func() {
@@ -65,7 +63,7 @@ func testRemoveGWLabelFromWorkerNodes() {
 			fake.NewFailingReactorForResource(&t.kubeClient.Fake, "nodes").SetFailOnUpdate(errors.New("fake error"))
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			Expect(t.client.RemoveGWLabelFromWorkerNodes(ctx)).ToNot(Succeed())
 		})
 	})
@@ -79,10 +77,10 @@ func testAddGWLabelOnNode() {
 	})
 
 	When("the gateway label isn't present", func() {
-		It("should add it", func() {
+		It("should add it", func(ctx SpecContext) {
 			Expect(t.client.AddGWLabelOnNode(ctx, "node")).To(Succeed())
-			t.assertLabel(t.nodes[0].Name, k8s.SubmarinerGatewayLabel, "true")
-			t.assertLabel(t.nodes[0].Name, "foo", "bar")
+			t.assertLabel(ctx, t.nodes[0].Name, k8s.SubmarinerGatewayLabel, "true")
+			t.assertLabel(ctx, t.nodes[0].Name, "foo", "bar")
 		})
 	})
 
@@ -91,9 +89,9 @@ func testAddGWLabelOnNode() {
 			t.nodes[0].Labels[k8s.SubmarinerGatewayLabel] = "false"
 		})
 
-		It("should set it to true", func() {
+		It("should set it to true", func(ctx SpecContext) {
 			Expect(t.client.AddGWLabelOnNode(ctx, t.nodes[0].Name)).To(Succeed())
-			t.assertLabel(t.nodes[0].Name, k8s.SubmarinerGatewayLabel, "true")
+			t.assertLabel(ctx, t.nodes[0].Name, k8s.SubmarinerGatewayLabel, "true")
 		})
 	})
 
@@ -102,7 +100,7 @@ func testAddGWLabelOnNode() {
 			t.nodes[0].Labels[k8s.SubmarinerGatewayLabel] = "true"
 		})
 
-		It("should not try to update it", func() {
+		It("should not try to update it", func(ctx SpecContext) {
 			Expect(t.client.AddGWLabelOnNode(ctx, t.nodes[0].Name)).To(Succeed())
 
 			actualActions := t.kubeClient.Fake.Actions()
@@ -119,9 +117,9 @@ func testAddGWLabelOnNode() {
 			t.nodes[0].Labels = nil
 		})
 
-		It("should add the gateway label", func() {
+		It("should add the gateway label", func(ctx SpecContext) {
 			Expect(t.client.AddGWLabelOnNode(ctx, t.nodes[0].Name)).To(Succeed())
-			t.assertLabel(t.nodes[0].Name, k8s.SubmarinerGatewayLabel, "true")
+			t.assertLabel(ctx, t.nodes[0].Name, k8s.SubmarinerGatewayLabel, "true")
 		})
 	})
 
@@ -130,7 +128,7 @@ func testAddGWLabelOnNode() {
 			t.nodes = nil
 		})
 
-		It("should not return an error", func() {
+		It("should not return an error", func(ctx SpecContext) {
 			Expect(t.client.AddGWLabelOnNode(ctx, "node")).To(Succeed())
 		})
 	})
@@ -140,7 +138,7 @@ func testAddGWLabelOnNode() {
 			fake.NewFailingReactorForResource(&t.kubeClient.Fake, "nodes").SetFailOnUpdate(errors.New("fake error"))
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			Expect(t.client.AddGWLabelOnNode(ctx, t.nodes[0].Name)).ToNot(Succeed())
 		})
 	})
@@ -158,7 +156,7 @@ func testListGatewayNodes() {
 		}
 	})
 
-	It("should return the correct nodes", func() {
+	It("should return the correct nodes", func(ctx SpecContext) {
 		list, err := t.client.ListGatewayNodes(ctx)
 		Expect(err).To(Succeed())
 
@@ -170,7 +168,7 @@ func testListGatewayNodes() {
 			fake.NewFailingReactorForResource(&t.kubeClient.Fake, "nodes").SetFailOnList(errors.New("fake error"))
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			_, err := t.client.ListGatewayNodes(ctx)
 			Expect(err).ToNot(Succeed())
 		})
@@ -189,10 +187,10 @@ func testListNodesWithLabel() {
 		}
 	})
 
-	It("should return the correct nodes", func() {
-		t.testListNodesWithLabel("label1=false", "node-1", "node-4")
-		t.testListNodesWithLabel("label1=true", "node-2")
-		t.testListNodesWithLabel("label2=true")
+	It("should return the correct nodes", func(ctx SpecContext) {
+		t.testListNodesWithLabel(ctx, "label1=false", "node-1", "node-4")
+		t.testListNodesWithLabel(ctx, "label1=true", "node-2")
+		t.testListNodesWithLabel(ctx, "label2=true")
 	})
 
 	Context("on failure", func() {
@@ -200,7 +198,7 @@ func testListNodesWithLabel() {
 			fake.NewFailingReactorForResource(&t.kubeClient.Fake, "nodes").SetFailOnList(errors.New("fake error"))
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			_, err := t.client.ListNodesWithLabel(ctx, "")
 			Expect(err).ToNot(Succeed())
 		})
@@ -220,9 +218,9 @@ func newInterfaceTestDriver() *interfaceTestDriver {
 		t.kubeClient = kubeFake.NewClientset()
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		for _, node := range t.nodes {
-			_, err := t.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+			_, err := t.kubeClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 			Expect(err).To(Succeed())
 		}
 
@@ -234,21 +232,21 @@ func newInterfaceTestDriver() *interfaceTestDriver {
 	return t
 }
 
-func (t *interfaceTestDriver) testListNodesWithLabel(labelSelector string, expNodes ...string) {
+func (t *interfaceTestDriver) testListNodesWithLabel(ctx context.Context, labelSelector string, expNodes ...string) {
 	list, err := t.client.ListNodesWithLabel(ctx, labelSelector)
 	Expect(err).To(Succeed())
 
 	assertNodeNames(list, expNodes...)
 }
 
-func (t *interfaceTestDriver) assertLabel(name, key, value string) {
-	node, err := t.kubeClient.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+func (t *interfaceTestDriver) assertLabel(ctx context.Context, name, key, value string) {
+	node, err := t.kubeClient.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
 	Expect(err).To(Succeed())
 	Expect(node.Labels).To(HaveKeyWithValue(key, value))
 }
 
-func (t *interfaceTestDriver) assertNoLabel(name, key string) {
-	node, err := t.kubeClient.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+func (t *interfaceTestDriver) assertNoLabel(ctx context.Context, name, key string) {
+	node, err := t.kubeClient.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
 	Expect(err).To(Succeed())
 	Expect(node.Labels).ToNot(HaveKey(key))
 }

--- a/pkg/ocp/machinesets_test.go
+++ b/pkg/ocp/machinesets_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package ocp_test
 
 import (
-	"context"
 	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -36,8 +35,6 @@ import (
 	fakeClient "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 )
-
-var ctx = context.TODO()
 
 var _ = Describe("K8s MachineSetDeployer", func() {
 	const (
@@ -65,7 +62,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 
 	Context("on GetWorkerNodeImage", func() {
 		When("no worker node exists", func() {
-			It("should return an error", func() {
+			It("should return an error", func(ctx SpecContext) {
 				_, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
 				Expect(err).ToNot(Succeed())
 			})
@@ -76,7 +73,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				machineSet.SetName(infraID + "-worker-c")
 			})
 
-			JustBeforeEach(func() {
+			JustBeforeEach(func(ctx SpecContext) {
 				_, err := msClient.Create(ctx, machineSet, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
 			})
@@ -92,7 +89,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 					_ = unstructured.SetNestedSlice(machineSet.Object, disks, "spec", "template", "spec", "providerSpec", "value", "disks")
 				})
 
-				It("should return its disk image", func() {
+				It("should return its disk image", func(ctx SpecContext) {
 					image, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
 					Expect(err).To(Succeed())
 					Expect(image).To(Equal("some-image"))
@@ -100,7 +97,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 			})
 
 			Context("and has no disks", func() {
-				It("should return an error", func() {
+				It("should return an error", func(ctx SpecContext) {
 					_, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
 					Expect(err).ToNot(Succeed())
 				})
@@ -114,7 +111,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 					fake.NewFailingReactor(&dynClient.Fake).SetFailOnList(expectedErr)
 				})
 
-				It("should return an error", func() {
+				It("should return an error", func(ctx SpecContext) {
 					_, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
 					Expect(err).To(ContainErrorSubstring(expectedErr))
 				})
@@ -127,7 +124,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 			machineSet.SetName(machineSetName)
 		})
 
-		It("should successfully create the machine set", func() {
+		It("should successfully create the machine set", func(ctx SpecContext) {
 			Expect(deployer.Deploy(ctx, machineSet)).To(Succeed())
 
 			_, err := msClient.Get(ctx, machineSetName, metav1.GetOptions{})
@@ -141,12 +138,12 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 		})
 
 		When("the machine set exists", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				_, err := msClient.Create(ctx, machineSet, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
 			})
 
-			It("should successfully delete the machine set", func() {
+			It("should successfully delete the machine set", func(ctx SpecContext) {
 				Expect(deployer.Delete(ctx, machineSet)).To(Succeed())
 
 				_, err := msClient.Get(ctx, machineSetName, metav1.GetOptions{})
@@ -158,14 +155,14 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 					fake.NewFailingReactor(&dynClient.Fake).SetFailOnDelete(errors.New("fake Delete error"))
 				})
 
-				It("should return an error", func() {
+				It("should return an error", func(ctx SpecContext) {
 					Expect(deployer.Delete(ctx, machineSet)).ToNot(Succeed())
 				})
 			})
 		})
 
 		When("the machine set does not exist", func() {
-			It("should not return an error", func() {
+			It("should not return an error", func(ctx SpecContext) {
 				Expect(deployer.Delete(ctx, machineSet)).To(Succeed())
 			})
 		})
@@ -173,7 +170,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 
 	Context("on List", func() {
 		When("matching and non-matching machine sets exist", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				machineSet.SetName(machineSetName)
 				_, err := msClient.Create(ctx, machineSet, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
@@ -182,7 +179,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				Expect(err).To(Succeed())
 			})
 
-			It("should return only the matching machine set", func() {
+			It("should return only the matching machine set", func(ctx SpecContext) {
 				machineSetList, err := deployer.List(ctx)
 				Expect(err).To(Succeed())
 
@@ -192,7 +189,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 		})
 
 		When("a matching machine set does not exist", func() {
-			It("should not return an error", func() {
+			It("should not return an error", func(ctx SpecContext) {
 				machineSetList, err := deployer.List(ctx)
 				Expect(err).To(Succeed())
 				Expect(machineSetList).To(BeEmpty())

--- a/pkg/rhos/ocpgwdeployer_test.go
+++ b/pkg/rhos/ocpgwdeployer_test.go
@@ -52,7 +52,7 @@ func testDeploy() {
 		t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, mock.Anything, testInfraID).Return(testImage, nil).Maybe()
 	})
 
-	It("should deploy a gateway node machine set and security group rules", func() {
+	It("should deploy a gateway node machine set and security group rules", func(ctx SpecContext) {
 		Expect(t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout())).To(Succeed())
 
 		t.assertMachineSet(false, SubnetParam{
@@ -78,7 +78,7 @@ func testDeploy() {
 			t.subnetNames = []string{subnetName1, subnetName2}
 		})
 
-		It("should deploy a gateway node machine with the subnets applied", func() {
+		It("should deploy a gateway node machine with the subnets applied", func(ctx SpecContext) {
 			Expect(t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout())).To(Succeed())
 
 			t.assertMachineSet(false, SubnetParam{
@@ -102,7 +102,7 @@ func testDeploy() {
 			}
 		})
 
-		It("should deploy a gateway node machine set with the internal security group", func() {
+		It("should deploy a gateway node machine set with the internal security group", func(ctx SpecContext) {
 			Expect(t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout())).To(Succeed())
 			t.assertMachineSet(true)
 		})
@@ -117,29 +117,29 @@ func testDeploy() {
 			}
 		})
 
-		It("should not try to recreate it", func() {
+		It("should not try to recreate it", func(ctx SpecContext) {
 			Expect(t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout())).To(Succeed())
 			Expect(t.securityGroupsCreated).To(BeEmpty())
 		})
 	})
 
 	When("a node is already labeled as a gateway", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			for _, name := range []string{nodeName1, nodeName2} {
-				t.createGatewayNode(name)
+				t.createGatewayNode(ctx, name)
 			}
 		})
 
-		It("should open the gateway port and not deploy a machine set", func() {
+		It("should open the gateway port and not deploy a machine set", func(ctx SpecContext) {
 			Expect(t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout())).To(Succeed())
 			t.assertServerSecGroup(gwSecurityGroup)
 		})
 
-		t.testErrors(func() error { return t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout()) },
+		t.testErrors(func(ctx context.Context) error { return t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout()) },
 			extractServersErrEntry())
 	})
 
-	t.testErrors(func() error { return t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout()) },
+	t.testErrors(func(ctx context.Context) error { return t.gwDeployer.Deploy(ctx, t.gwDeployInput, reporter.Stdout()) },
 		newComputeV2ErrEntry(),
 		newNetworkV2ErrEntry(),
 		createSecurityGroupErrEntry(),
@@ -149,7 +149,7 @@ func testDeploy() {
 func testCleanup() {
 	t := newGatewayDeployerTestDriver()
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx SpecContext) {
 		t.existingMachineSets = []unstructured.Unstructured{
 			{
 				Object: map[string]any{
@@ -180,10 +180,10 @@ func testCleanup() {
 
 		t.servers[nodeName3] = &servers.Server{ID: serverID3}
 
-		t.createGatewayNode(nodeName3)
+		t.createGatewayNode(ctx, nodeName3)
 	})
 
-	It("should delete the gateway machine sets and security groups", func() {
+	It("should delete the gateway machine sets and security groups", func(ctx SpecContext) {
 		Expect(t.gwDeployer.Cleanup(ctx, reporter.Stdout())).To(Succeed())
 		Expect(t.existingMachineSets).To(BeEmpty())
 		Expect(t.existingSecurityGroups).To(BeEmpty())
@@ -194,7 +194,7 @@ func testCleanup() {
 		Expect(node.Labels).NotTo(HaveKey(k8s.SubmarinerGatewayLabel))
 	})
 
-	t.testErrors(func() error { return t.gwDeployer.Cleanup(ctx, reporter.Stdout()) },
+	t.testErrors(func(ctx context.Context) error { return t.gwDeployer.Cleanup(ctx, reporter.Stdout()) },
 		newComputeV2ErrEntry(),
 		deleteSecurityGroupErrEntry(),
 		extractSecurityGroupsErrEntry(),
@@ -319,7 +319,7 @@ func (t *gatewayDeployerTestDriver) assertMachineSet(useInternalSG bool, expSubn
 	})).To(Equal(useInternalSG))
 }
 
-func (t *gatewayDeployerTestDriver) createGatewayNode(name string) {
+func (t *gatewayDeployerTestDriver) createGatewayNode(ctx context.Context, name string) {
 	_, err := t.kubeClient.CoreV1().Nodes().Create(ctx, &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,

--- a/pkg/rhos/rhos_suite_test.go
+++ b/pkg/rhos/rhos_suite_test.go
@@ -57,8 +57,6 @@ const (
 	internalSecurityGroup = testInfraID + rhos.InternalSecurityGroupSuffix
 )
 
-var ctx = context.TODO()
-
 func TestRHOS(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "RHOS Suite")
@@ -255,7 +253,7 @@ func (t *testDriver) assertNoServerSecGroup(groupName string) {
 	}
 }
 
-func (t *testDriver) testErrors(run func() error, entries ...any) {
+func (t *testDriver) testErrors(run func(ctx context.Context) error, entries ...any) {
 	params := []any{
 		func(message string, before func()) {
 			When(message+" fails", func() {
@@ -263,8 +261,8 @@ func (t *testDriver) testErrors(run func() error, entries ...any) {
 					before()
 				})
 
-				It("should return an error", func() {
-					Expect(run()).NotTo(Succeed())
+				It("should return an error", func(ctx SpecContext) {
+					Expect(run(ctx)).NotTo(Succeed())
 				})
 			})
 		},

--- a/pkg/rhos/rhos_test.go
+++ b/pkg/rhos/rhos_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package rhos_test
 
 import (
+	"context"
+
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/secgroups"
 	. "github.com/onsi/ginkgo/v2"
@@ -54,7 +56,7 @@ func testOpenPorts() {
 	})
 
 	When("the internal security group does not exist", func() {
-		It("should create the security group and open internal ports", func() {
+		It("should create the security group and open internal ports", func(ctx SpecContext) {
 			Expect(t.cloud.OpenPorts(ctx, ports, reporter.Stdout())).To(Succeed())
 
 			Expect(t.securityGroupsCreated).To(ContainElement(internalSecurityGroup))
@@ -77,7 +79,7 @@ func testOpenPorts() {
 			}
 		})
 
-		It("should not recreate it but should add servers to it", func() {
+		It("should not recreate it but should add servers to it", func(ctx SpecContext) {
 			Expect(t.cloud.OpenPorts(ctx, ports, reporter.Stdout())).To(Succeed())
 
 			Expect(t.securityGroupsCreated).To(BeEmpty())
@@ -85,7 +87,7 @@ func testOpenPorts() {
 		})
 	})
 
-	t.testErrors(func() error { return t.cloud.OpenPorts(ctx, ports, reporter.Stdout()) },
+	t.testErrors(func(ctx context.Context) error { return t.cloud.OpenPorts(ctx, ports, reporter.Stdout()) },
 		newComputeV2ErrEntry(),
 		newNetworkV2ErrEntry(),
 		createSecurityGroupErrEntry(),
@@ -113,13 +115,13 @@ func testClosePorts() {
 		}
 	})
 
-	It("should remove the security group from servers and delete it", func() {
+	It("should remove the security group from servers and delete it", func(ctx SpecContext) {
 		Expect(t.cloud.ClosePorts(ctx, reporter.Stdout())).To(Succeed())
 
 		t.assertNoServerSecGroup(internalSecurityGroup)
 	})
 
-	t.testErrors(func() error { return t.cloud.ClosePorts(ctx, reporter.Stdout()) },
+	t.testErrors(func(ctx context.Context) error { return t.cloud.ClosePorts(ctx, reporter.Stdout()) },
 		newComputeV2ErrEntry(),
 		deleteSecurityGroupErrEntry(),
 		extractSecurityGroupsErrEntry(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to properly propagate context through test lifecycle hooks and helper methods across AWS, Azure, GCP, and Kubernetes test suites.

* **Refactor**
  * Updated OpenPorts and ClosePorts method signatures in cloud operation APIs to include explicit writer parameter for output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->