### PR TITLE
AWS: enforce security groups specified when custom VPC specified

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -31,10 +31,9 @@ import (
 )
 
 const (
-	messageRetrieveVPCID          = "Retrieving VPC ID"
-	messageRetrievedVPCID         = "Retrieved VPC ID %s"
-	messageValidatePrerequisites  = "Validating pre-requisites"
-	messageValidatedPrerequisites = "Validated pre-requisites"
+	messageRetrieveVPCID         = "Retrieving VPC ID"
+	messageRetrievedVPCID        = "Retrieved VPC ID %s"
+	messageValidatePrerequisites = "Validating pre-requisites"
 )
 
 type CloudOption func(*awsCloud)
@@ -131,19 +130,19 @@ func (ac *awsCloud) setSuffixes(ctx context.Context, vpcID string) error {
 
 func (ac *awsCloud) OpenPorts(ctx context.Context, ports []api.PortSpec, status reporter.Interface) error {
 	status.Start(messageRetrieveVPCID)
-	defer status.End()
 
 	vpcID, err := ac.getVpcID(ctx)
 	if err != nil {
 		return status.Error(err, "unable to retrieve the VPC ID")
 	}
 
+	status.Success(messageRetrievedVPCID, vpcID)
+	status.End()
+
 	err = ac.setSuffixes(ctx, vpcID)
 	if err != nil {
 		return status.Error(err, "")
 	}
-
-	status.Success(messageRetrievedVPCID, vpcID)
 
 	status.Start(messageValidatePrerequisites)
 
@@ -152,7 +151,7 @@ func (ac *awsCloud) OpenPorts(ctx context.Context, ports []api.PortSpec, status 
 		return status.Error(err, "unable to validate prerequisites")
 	}
 
-	status.Success(messageValidatedPrerequisites)
+	status.End()
 
 	for _, port := range ports {
 		status.Start("Opening port %v protocol %s for intra-cluster communications", port.Port, port.Protocol)
@@ -162,7 +161,7 @@ func (ac *awsCloud) OpenPorts(ctx context.Context, ports []api.PortSpec, status 
 			return status.Error(err, "unable to open port")
 		}
 
-		status.Success("Opened port %v protocol %s for intra-cluster communications", port.Port, port.Protocol)
+		status.End()
 	}
 
 	return nil
@@ -174,19 +173,19 @@ func (ac *awsCloud) validatePreparePrerequisites(ctx context.Context, vpcID stri
 
 func (ac *awsCloud) ClosePorts(ctx context.Context, status reporter.Interface) error {
 	status.Start(messageRetrieveVPCID)
-	defer status.End()
 
 	vpcID, err := ac.getVpcID(ctx)
 	if err != nil {
 		return status.Error(err, "unable to retrieve the VPC ID")
 	}
 
+	status.Success(messageRetrievedVPCID, vpcID)
+	status.End()
+
 	err = ac.setSuffixes(ctx, vpcID)
 	if err != nil {
 		return status.Error(err, "")
 	}
-
-	status.Success(messageRetrievedVPCID, vpcID)
 
 	status.Start(messageValidatePrerequisites)
 
@@ -195,7 +194,7 @@ func (ac *awsCloud) ClosePorts(ctx context.Context, status reporter.Interface) e
 		return status.Error(err, "unable to validate prerequisites")
 	}
 
-	status.Success(messageValidatedPrerequisites)
+	status.End()
 
 	status.Start("Revoking intra-cluster communication permissions")
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -91,8 +91,12 @@ func NewCloud(client awsClient.Interface, infraID, region string, opts ...CloudO
 }
 
 func (ac *awsCloud) setSuffixes(ctx context.Context, vpcID string) error {
-	if ac.nodeSGSuffix != "" || ac.vpcID != "" {
+	if ac.nodeSGSuffix != "" || (ac.workerGroupID != "" && ac.controlPlaneGroupID != "") {
 		return nil
+	}
+
+	if ac.vpcID != "" {
+		return errors.New("when a custom VPC is specified, both worker and control plane security groups must also be specified")
 	}
 
 	publicSubnets, err := ac.findPublicSubnets(ctx, vpcID, ac.publicFilter())

--- a/pkg/aws/aws_cloud_test.go
+++ b/pkg/aws/aws_cloud_test.go
@@ -90,7 +90,7 @@ func testOpenPorts() {
 
 		Context("WithControlPlaneSecurityGroup", func() {
 			BeforeEach(func() {
-				t.masterGroupID = "custom-master-group"
+				t.masterGroupID = customMasterGroup
 				t.cloudOptions = append(t.cloudOptions, aws.WithControlPlaneSecurityGroup(t.masterGroupID))
 			})
 
@@ -122,13 +122,14 @@ func testOpenPorts() {
 			})
 		})
 
-		PContext("WithVPCName", func() {
+		Context("WithVPCName and WithWorkerSecurityGroup and WithControlPlaneSecurityGroup", func() {
 			BeforeEach(func() {
 				t.existingVpcs = []types.Vpc{}
-				t.vpcID = "custom-vpc"
-				t.workerSGName = infraID
-				t.masterSGName = infraID
-				t.cloudOptions = append(t.cloudOptions, aws.WithVPCName(t.vpcID))
+				t.vpcID = customVPC
+				t.masterGroupID = customMasterGroup
+				t.workerGroupID = customWorkerGroup
+				t.cloudOptions = append(t.cloudOptions, aws.WithVPCName(t.vpcID), aws.WithControlPlaneSecurityGroup(t.masterGroupID),
+					aws.WithWorkerSecurityGroup(t.workerGroupID))
 			})
 
 			It("should authorize the appropriate security groups ingress", func(ctx SpecContext) {
@@ -143,7 +144,19 @@ func testOpenPorts() {
 		})
 
 		It("should return an error", func(ctx SpecContext) {
-			Expect(doOpenPorts(ctx)).To(HaveOccurred())
+			Expect(doOpenPorts(ctx)).NotTo(Succeed())
+		})
+	})
+
+	Context("WithVPCName without worker and control plane security groups specified", func() {
+		BeforeEach(func() {
+			t.existingVpcs = []types.Vpc{}
+			t.vpcID = customVPC
+			t.cloudOptions = append(t.cloudOptions, aws.WithVPCName(t.vpcID))
+		})
+
+		It("should return an error", func(ctx SpecContext) {
+			Expect(doOpenPorts(ctx)).NotTo(Succeed())
 		})
 	})
 
@@ -154,7 +167,7 @@ func testOpenPorts() {
 		})
 
 		It("should return an error", func(ctx SpecContext) {
-			Expect(doOpenPorts(ctx)).To(HaveOccurred())
+			Expect(doOpenPorts(ctx)).NotTo(Succeed())
 		})
 	})
 
@@ -165,7 +178,7 @@ func testOpenPorts() {
 		})
 
 		It("should return an error", func(ctx SpecContext) {
-			Expect(doOpenPorts(ctx)).To(HaveOccurred())
+			Expect(doOpenPorts(ctx)).NotTo(Succeed())
 		})
 	})
 }
@@ -217,7 +230,7 @@ func testClosePorts() {
 
 		Context("WithControlPlaneSecurityGroup", func() {
 			BeforeEach(func() {
-				t.masterGroupID = "custom-master-group"
+				t.masterGroupID = customMasterGroup
 				t.cloudOptions = append(t.cloudOptions, aws.WithControlPlaneSecurityGroup(t.masterGroupID))
 
 				t.expectDescribeSecurityGroupsByID(t.masterGroupID, ipPerm)

--- a/pkg/aws/aws_suite_test.go
+++ b/pkg/aws/aws_suite_test.go
@@ -50,6 +50,8 @@ const (
 	clusterFilterTagName     = "tag:kubernetes.io/cluster/" + infraID
 	clusterFilterTagNameSigs = providerAWSTagPrefix + infraID
 	customWorkerGroup        = "custom-worker-group"
+	customMasterGroup        = "custom-master-group"
+	customVPC                = "custom-vpc"
 )
 
 var internalTrafficDesc = fmt.Sprintf("Should contain %q", internalTraffic)

--- a/pkg/aws/ocpgwdeployer.go
+++ b/pkg/aws/ocpgwdeployer.go
@@ -60,7 +60,6 @@ func NewOcpGatewayDeployer(cloud api.Cloud, msDeployer ocp.MachineSetDeployer, i
 
 func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeployInput, status reporter.Interface) error {
 	status.Start(messageRetrieveVPCID)
-	defer status.End()
 
 	vpcID, err := d.aws.getVpcID(ctx)
 	if err != nil {
@@ -68,6 +67,7 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 	}
 
 	status.Success(messageRetrievedVPCID, vpcID)
+	status.End()
 
 	err = d.aws.setSuffixes(ctx, vpcID)
 	if err != nil {
@@ -86,7 +86,7 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 		return status.Error(err, "unable to validate prerequisites")
 	}
 
-	status.Success(messageValidatedPrerequisites)
+	status.End()
 
 	status.Start("Creating Submariner gateway security group")
 
@@ -96,6 +96,7 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 	}
 
 	status.Success("Created Submariner gateway security group %s", gatewaySG)
+	status.End()
 
 	return d.processSubnets(ctx, vpcID, gatewaySG, publicSubnets, input, status)
 }
@@ -336,6 +337,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 	}
 
 	status.Success(messageRetrievedVPCID, vpcID)
+	status.End()
 
 	err = d.aws.setSuffixes(ctx, vpcID)
 	if err != nil {
@@ -349,7 +351,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 		return status.Error(err, "unable to validate prerequisites")
 	}
 
-	status.Success(messageValidatedPrerequisites)
+	status.End()
 
 	publicSubnets, err := d.aws.findPublicSubnets(ctx, vpcID, submarinerGatewayFilter())
 	if err != nil {
@@ -367,7 +369,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 			return status.Error(err, "unable to remove gateway node")
 		}
 
-		status.Success("Removed gateway node for public subnet %s", subnetName)
+		status.End()
 
 		status.Start("Untagging public subnet %s from supporting Submariner", subnetName)
 
@@ -376,7 +378,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 			return status.Error(err, "unable to untag subnet")
 		}
 
-		status.Success("Untagged public subnet %s from supporting Submariner", subnetName)
+		status.End()
 	}
 
 	status.Start("Deleting Submariner gateway security group")
@@ -386,7 +388,7 @@ func (d *ocpGatewayDeployer) Cleanup(ctx context.Context, status reporter.Interf
 		return status.Error(err, "unable to delete gateway")
 	}
 
-	status.Success("Deleted Submariner gateway security group")
+	status.End()
 
 	return nil
 }

--- a/pkg/aws/ocpgwdeployer_test.go
+++ b/pkg/aws/ocpgwdeployer_test.go
@@ -123,10 +123,14 @@ func testDeploy() {
 		Context("WithVPCName", func() {
 			BeforeEach(func() {
 				t.existingVpcs = []types.Vpc{}
-				t.vpcID = "custom-vpc"
-				t.workerSGName = infraID
-				t.masterSGName = infraID
-				t.cloudOptions = append(t.cloudOptions, aws.WithVPCName(t.vpcID))
+				t.vpcID = customVPC
+				t.masterGroupID = customMasterGroup
+				t.workerGroupID = customWorkerGroup
+				t.cloudOptions = append(t.cloudOptions, aws.WithVPCName(t.vpcID), aws.WithControlPlaneSecurityGroup(t.masterGroupID),
+					aws.WithWorkerSecurityGroup(t.workerGroupID))
+				t.workerSGName = customWorkerGroup + "-name"
+
+				t.expectDescribeSecurityGroupsByID(t.workerGroupID)
 			})
 
 			t.testDeploySuccess("", "")


### PR DESCRIPTION
Fixes https://github.com/submariner-io/cloud-prepare/issues/1278


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter VPC validation: specifying a custom VPC now requires both worker and control-plane security groups.
  * Streamlined progress reporting: removed redundant per-port and per-phase success logs and closed prerequisite steps earlier for clearer deployment/cleanup output.

* **Tests**
  * Expanded VPC/security-group test coverage, replaced literal IDs with reusable test constants, and added scenarios validating error behavior when only a VPC is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->