### PR TITLE
Automated backport of #1241: Add region check when selecting zone

### DIFF
--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -275,17 +275,43 @@ func (d *ocpGatewayDeployer) getAvailabilityZones(gwNodes []unstructured.Unstruc
 		}
 
 		for _, resourceSKU := range nextResult.Value {
-			if *resourceSKU.ResourceType == azureVirtualMachines && *resourceSKU.Name == d.instanceType {
-				for _, zone := range resourceSKU.LocationInfo[0].Zones {
-					if !zonesWithSubmarinerGW.Has(d.azure.Region + "-" + *zone) {
-						eligibleZonesForSubmarinerGW.Insert(*zone)
-					}
-				}
-			}
+			zones := d.filterZonesByRegion(resourceSKU, zonesWithSubmarinerGW)
+			eligibleZonesForSubmarinerGW = eligibleZonesForSubmarinerGW.Union(zones)
 		}
 	}
 
 	return eligibleZonesForSubmarinerGW, nil
+}
+
+func (d *ocpGatewayDeployer) filterZonesByRegion(resourceSKU *armcompute.ResourceSKU, zonesWithSubmarinerGW set.Set[string],
+) set.Set[string] {
+	eligibleZones := set.New[string]()
+
+	if resourceSKU == nil || resourceSKU.ResourceType == nil || resourceSKU.Name == nil {
+		return eligibleZones
+	}
+
+	if *resourceSKU.ResourceType != azureVirtualMachines || *resourceSKU.Name != d.instanceType {
+		return eligibleZones
+	}
+
+	for _, locationInfo := range resourceSKU.LocationInfo {
+		if locationInfo == nil || locationInfo.Location == nil || *locationInfo.Location != d.azure.Region {
+			continue
+		}
+
+		for _, zone := range locationInfo.Zones {
+			if zone == nil {
+				continue
+			}
+
+			if !zonesWithSubmarinerGW.Has(*zone) {
+				eligibleZones.Insert(*zone)
+			}
+		}
+	}
+
+	return eligibleZones
 }
 
 func (d *ocpGatewayDeployer) Cleanup(status reporter.Interface) error {

--- a/pkg/azure/ocpgwdeployer_internal_test.go
+++ b/pkg/azure/ocpgwdeployer_internal_test.go
@@ -19,12 +19,15 @@ limitations under the License.
 package azure
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	"github.com/submariner-io/admiral/pkg/util"
 	ocpFake "github.com/submariner-io/cloud-prepare/pkg/ocp/fake"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+	"k8s.io/utils/set"
 )
 
 var _ = Describe("OCP Gateway Deployer", func() {
@@ -87,6 +90,54 @@ var _ = Describe("OCP Gateway Deployer", func() {
 
 			Expect(machineSet).ToNot(BeNil())
 			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "publicIP")).To(BeFalse())
+		})
+	})
+
+	Describe("filterZonesByRegion", func() {
+		It("should only return zones from matching region", func() {
+			resourceSKU := &armcompute.ResourceSKU{
+				Name:         ptr.To(instanceType),
+				ResourceType: ptr.To("virtualMachines"),
+				LocationInfo: []*armcompute.ResourceSKULocationInfo{
+					{
+						Location: ptr.To(region),
+						Zones:    []*string{ptr.To("1"), ptr.To("2"), ptr.To("3")},
+					},
+					{
+						Location: ptr.To("centralus"),
+						Zones:    []*string{ptr.To("1"), ptr.To("2"), ptr.To("3")},
+					},
+				},
+			}
+
+			zonesWithGW := set.New[string]()
+			zones := gwDeployer.filterZonesByRegion(resourceSKU, zonesWithGW)
+
+			Expect(zones.Len()).To(Equal(3))
+			Expect(zones.Has("1")).To(BeTrue())
+			Expect(zones.Has("2")).To(BeTrue())
+			Expect(zones.Has("3")).To(BeTrue())
+		})
+
+		It("should exclude zones with existing gateways", func() {
+			resourceSKU := &armcompute.ResourceSKU{
+				Name:         ptr.To(instanceType),
+				ResourceType: ptr.To("virtualMachines"),
+				LocationInfo: []*armcompute.ResourceSKULocationInfo{
+					{
+						Location: ptr.To(region),
+						Zones:    []*string{ptr.To("1"), ptr.To("2"), ptr.To("3")},
+					},
+				},
+			}
+
+			zonesWithGW := set.New[string]("1")
+			zones := gwDeployer.filterZonesByRegion(resourceSKU, zonesWithGW)
+
+			Expect(zones.Len()).To(Equal(2))
+			Expect(zones.Has("1")).To(BeFalse())
+			Expect(zones.Has("2")).To(BeTrue())
+			Expect(zones.Has("3")).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
Backport of #1241 on release-0.22.

#1241: Add region check when selecting zone

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized Azure gateway availability zone selection with improved region-aware filtering and exclusion of zones that already host gateways.
* **Tests**
  * Added unit tests covering region-specific zone filtering and proper exclusion of zones with existing gateways.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->