### PR TITLE
Automated backport of #1239: Add kubenertes tag in the security group

### DIFF
--- a/pkg/aws/aws_suite_test.go
+++ b/pkg/aws/aws_suite_test.go
@@ -222,6 +222,10 @@ func (f *fakeAWSClientBase) expectCreateSecurityGroup(name, retGroupID string) {
 						Key:   ptr.To("Name"),
 						Value: ptr.To(name),
 					},
+					{
+						Key:   ptr.To("kubernetes.io/cluster/" + infraID),
+						Value: ptr.To("owned"),
+					},
 				},
 			},
 		},

--- a/pkg/aws/securitygroups.go
+++ b/pkg/aws/securitygroups.go
@@ -195,6 +195,7 @@ func (ac *awsCloud) createGatewaySG(vpcID string, ports []api.PortSpec) (string,
 					ResourceType: types.ResourceTypeSecurityGroup,
 					Tags: []types.Tag{
 						ec2Tag("Name", groupName),
+						ec2Tag(ac.withAWSInfo("kubernetes.io/cluster/{infraID}"), "owned"),
 					},
 				},
 			},


### PR DESCRIPTION
Backport of #1239 on release-0.22.

#1239: Add kubenertes tag in the security group

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.