### PR TITLE
Fix wsl_v5 linter warnings reported in golangci-lint 2.9.0

### DIFF
--- a/pkg/ocp/machinesets_test.go
+++ b/pkg/ocp/machinesets_test.go
@@ -174,6 +174,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				machineSet.SetName(machineSetName)
 				_, err := msClient.Create(ctx, machineSet, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
+
 				machineSet = newMachineSet("false")
 				_, err = msClient.Create(ctx, machineSet, metav1.CreateOptions{})
 				Expect(err).To(Succeed())


### PR DESCRIPTION
Add blank lines before return and go statements to satisfy wsl_v5 whitespace requirements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for MachineSet filtering to verify that the List operation correctly handles multiple configurations and returns only matching results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->