### PR TITLE
Remove unused nolint directive for gosec

### DIFF
--- a/pkg/aws/client/client_test.go
+++ b/pkg/aws/client/client_test.go
@@ -140,7 +140,7 @@ func createTempFile(name, data string) string {
 	Expect(err).NotTo(HaveOccurred())
 
 	DeferCleanup(func() {
-		_ = os.Remove(file.Name()) //nolint:gosec // Test cleanup of temp file
+		_ = os.Remove(file.Name())
 	})
 
 	return file.Name()


### PR DESCRIPTION
...as the `gosec` linter no longer flags a false positive for "_G703 path traversal warning in test cleanup_" on this line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed linting directive from test infrastructure with no functional changes to application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->