### PR TITLE
Automated backport of #1328: Support Azure Marketplace images for gateway MachineSet

### DIFF
--- a/pkg/azure/gw-machineset.go
+++ b/pkg/azure/gw-machineset.go
@@ -55,11 +55,12 @@ spec:
             name: azure-cloud-credentials
             namespace: openshift-machine-api
           image:
-            offer: ""
-            publisher: ""
-            resourceID: {{.Image}} 
-            sku: ""
-            version: ""
+            offer: "{{.ImageOffer}}"
+            publisher: "{{.ImagePublisher}}"
+            resourceID: "{{.ImageResourceID}}"
+            sku: "{{.ImageSKU}}"
+            version: "{{.ImageVersion}}"
+            type: "{{.ImageType}}"
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
           location: {{.Region}}

--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -130,11 +130,11 @@ func (d *ocpGatewayDeployer) Deploy(ctx context.Context, input api.GatewayDeploy
 		return errors.Wrap(imageErr, "error retrieving worker node image")
 	}
 
-	return d.deployDedicatedGWNode(ctx, machineSets, gatewayNodesToDeploy, input.AirGapped, image, status)
+	return d.deployDedicatedGWNode(ctx, machineSets, gatewayNodesToDeploy, input.AirGapped, &image, status)
 }
 
 func (d *ocpGatewayDeployer) deployDedicatedGWNode(ctx context.Context, gwNodes []unstructured.Unstructured,
-	gatewayNodesToDeploy int, airGapped bool, image string, status reporter.Interface,
+	gatewayNodesToDeploy int, airGapped bool, image *ocp.ImageSpec, status reporter.Interface,
 ) error {
 	status.Start("Retrieving the availability zones for region %q ", d.Region)
 
@@ -170,16 +170,21 @@ func (d *ocpGatewayDeployer) deployDedicatedGWNode(ctx context.Context, gwNodes 
 }
 
 type machineSetConfig struct {
-	Name         string
-	AZ           string
-	InfraID      string
-	InstanceType string
-	Region       string
-	Image        string
-	PublicIP     string
+	Name            string
+	AZ              string
+	InfraID         string
+	InstanceType    string
+	Region          string
+	ImageResourceID string
+	ImageOffer      string
+	ImagePublisher  string
+	ImageSKU        string
+	ImageVersion    string
+	ImageType       string
+	PublicIP        string
 }
 
-func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone, image string, airGapped bool) ([]byte, error) {
+func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone string, image *ocp.ImageSpec, airGapped bool) ([]byte, error) {
 	var buf bytes.Buffer
 
 	tpl, err := template.New("").Parse(machineSetYAML)
@@ -188,13 +193,18 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone, image string, airGapped
 	}
 
 	tplVars := machineSetConfig{
-		Name:         name,
-		InfraID:      d.InfraID,
-		InstanceType: d.instanceType,
-		Region:       d.Region,
-		AZ:           zone,
-		Image:        image,
-		PublicIP:     strconv.FormatBool(!airGapped),
+		Name:            name,
+		InfraID:         d.InfraID,
+		InstanceType:    d.instanceType,
+		Region:          d.Region,
+		AZ:              zone,
+		ImageResourceID: image.ResourceID,
+		ImageOffer:      image.Offer,
+		ImagePublisher:  image.Publisher,
+		ImageSKU:        image.SKU,
+		ImageVersion:    image.Version,
+		ImageType:       image.Type,
+		PublicIP:        strconv.FormatBool(!airGapped),
 	}
 
 	err = tpl.Execute(&buf, tplVars)
@@ -205,7 +215,7 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone, image string, airGapped
 	return buf.Bytes(), nil
 }
 
-func (d *ocpGatewayDeployer) initMachineSet(name, zone, image string, airGapped bool) (*unstructured.Unstructured, error) {
+func (d *ocpGatewayDeployer) initMachineSet(name, zone string, image *ocp.ImageSpec, airGapped bool) (*unstructured.Unstructured, error) {
 	gatewayYAML, err := d.loadGatewayYAML(name, zone, image, airGapped)
 	if err != nil {
 		return nil, err
@@ -223,7 +233,7 @@ func (d *ocpGatewayDeployer) initMachineSet(name, zone, image string, airGapped 
 	return machineSet, nil
 }
 
-func (d *ocpGatewayDeployer) deployGateway(ctx context.Context, zone, image string, airGapped bool) error {
+func (d *ocpGatewayDeployer) deployGateway(ctx context.Context, zone string, image *ocp.ImageSpec, airGapped bool) error {
 	machineSet, err := d.initMachineSet(MachineName(d.Region), zone, image, airGapped)
 	if err != nil {
 		return err

--- a/pkg/azure/ocpgwdeployer_test.go
+++ b/pkg/azure/ocpgwdeployer_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/submariner-io/cloud-prepare/pkg/api"
 	"github.com/submariner-io/cloud-prepare/pkg/azure"
 	"github.com/submariner-io/cloud-prepare/pkg/k8s"
+	"github.com/submariner-io/cloud-prepare/pkg/ocp"
 	ocpFake "github.com/submariner-io/cloud-prepare/pkg/ocp/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +47,17 @@ const (
 	nodeName1            = "node1"
 	nodeName2            = "node2"
 	extSecurityGroupName = testInfraID + azure.ExternalSecurityGroupSuffix
+)
+
+var (
+	resourceIDImageSpec  = ocp.ImageSpec{ResourceID: imageName}
+	marketplaceImageSpec = ocp.ImageSpec{
+		Offer:     "aro4",
+		Publisher: "azureopenshift",
+		SKU:       "420-v2",
+		Version:   "9.6.20251015",
+		Type:      "MarketplaceNoPlan",
+	}
 )
 
 var _ = Describe("OCP Gateway Deployer", func() {
@@ -68,7 +80,7 @@ var _ = Describe("OCP Gateway Deployer", func() {
 	})
 })
 
-func testDeploy() {
+func testDeploy() { //nolint:maintidx // Deploy test covers many scenarios; splitting would reduce readability.
 	t := newGatewayDeployerTestDriver()
 
 	When("gateways are requested", func() {
@@ -179,6 +191,20 @@ func testDeploy() {
 				}, reporter.Stdout())).To(Succeed())
 
 				t.assertMachineSets(true, 1, "zone1", "zone2", "zone3")
+			})
+		})
+
+		Context("with a Marketplace image (no resourceID)", func() {
+			BeforeEach(func() {
+				t.workerImage = marketplaceImageSpec
+			})
+
+			It("should deploy gateway machine sets using the Marketplace image fields", func(ctx SpecContext) {
+				Expect(t.deployer.Deploy(ctx, api.GatewayDeployInput{
+					Gateways: 1,
+				}, reporter.Stdout())).To(Succeed())
+
+				t.assertMachineSets(false, 1, "zone1", "zone2", "zone3")
 			})
 		})
 	})
@@ -381,6 +407,7 @@ type gatewayDeployerTestDriver struct {
 	deployer            api.GatewayDeployer
 	existingMachineSets []unstructured.Unstructured
 	machineSetsDeployed []*unstructured.Unstructured
+	workerImage         ocp.ImageSpec
 }
 
 func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
@@ -389,13 +416,14 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 	BeforeEach(func() {
 		t.existingMachineSets = nil
 		t.machineSetsDeployed = nil
+		t.workerImage = resourceIDImageSpec
 		t.msDeployer = ocpFake.NewMockMachineSetDeployer(GinkgoT())
 	})
 
 	JustBeforeEach(func() {
 		t.deployer = azure.NewOcpGatewayDeployer(&t.cloudInfo, t.msDeployer, instanceType)
 
-		t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, mock.Anything, t.cloudInfo.InfraID).Return(imageName, nil).Maybe()
+		t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, mock.Anything, t.cloudInfo.InfraID).Return(t.workerImage, nil).Maybe()
 		t.msDeployer.EXPECT().List(mock.Anything).Return(slices.Clone(t.existingMachineSets), nil).Maybe()
 		t.msDeployer.EXPECT().Deploy(mock.Anything, mock.Anything).RunAndReturn(
 			func(_ context.Context, ms *unstructured.Unstructured) error {
@@ -418,6 +446,10 @@ func newGatewayDeployerTestDriver() *gatewayDeployerTestDriver {
 }
 
 func (t *gatewayDeployerTestDriver) assertMachineSets(airGapped bool, count int, zones ...string) {
+	t.assertMachineSetsWithImage(airGapped, &t.workerImage, count, zones...)
+}
+
+func (t *gatewayDeployerTestDriver) assertMachineSetsWithImage(airGapped bool, image *ocp.ImageSpec, count int, zones ...string) {
 	zoneMatchers := make([]types.GomegaMatcher, len(zones))
 	for i := range zones {
 		zoneMatchers[i] = Equal(zones[i])
@@ -436,8 +468,21 @@ func (t *gatewayDeployerTestDriver) assertMachineSets(airGapped bool, count int,
 		Expect(values).To(HaveKeyWithValue("securityGroup", extSecurityGroupName))
 		Expect(values).To(HaveKeyWithValue("publicIP", !airGapped))
 
-		image, _, _ := unstructured.NestedString(values, "image", "resourceID")
-		Expect(image).To(Equal(imageName))
+		if image.ResourceID != "" {
+			actual, _, _ := unstructured.NestedString(values, "image", "resourceID")
+			Expect(actual).To(Equal(image.ResourceID))
+		} else {
+			actual, _, _ := unstructured.NestedString(values, "image", "offer")
+			Expect(actual).To(Equal(image.Offer))
+			actual, _, _ = unstructured.NestedString(values, "image", "publisher")
+			Expect(actual).To(Equal(image.Publisher))
+			actual, _, _ = unstructured.NestedString(values, "image", "sku")
+			Expect(actual).To(Equal(image.SKU))
+			actual, _, _ = unstructured.NestedString(values, "image", "version")
+			Expect(actual).To(Equal(image.Version))
+			actual, _, _ = unstructured.NestedString(values, "image", "type")
+			Expect(actual).To(Equal(image.Type))
+		}
 
 		Expect(values).To(HaveKeyWithValue("zone", Or(zoneMatchers...)))
 	}

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -235,10 +235,12 @@ func (d *ocpGatewayDeployer) deployGateway(ctx context.Context, zone string) err
 	}
 
 	if d.image == "" {
-		d.image, err = d.msDeployer.GetWorkerNodeImage(ctx, machineSet, d.InfraID)
+		imageSpec, err := d.msDeployer.GetWorkerNodeImage(ctx, machineSet, d.InfraID)
 		if err != nil {
 			return errors.Wrap(err, "error retrieving worker node image")
 		}
+
+		d.image = imageSpec.Image
 
 		machineSet, err = d.initMachineSet(zone)
 		if err != nil {

--- a/pkg/gcp/ocpgwdeployer_test.go
+++ b/pkg/gcp/ocpgwdeployer_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/submariner-io/cloud-prepare/pkg/api"
 	"github.com/submariner-io/cloud-prepare/pkg/gcp"
 	"github.com/submariner-io/cloud-prepare/pkg/k8s"
+	"github.com/submariner-io/cloud-prepare/pkg/ocp"
 	ocpFake "github.com/submariner-io/cloud-prepare/pkg/ocp/fake"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -126,7 +127,7 @@ func testDeploy() {
 		var machineSets map[string]*unstructured.Unstructured
 
 		BeforeEach(func() {
-			t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, mock.Anything, infraID).Return("test-image", nil).Maybe()
+			t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, mock.Anything, infraID).Return(ocp.ImageSpec{Image: "test-image"}, nil).Maybe()
 			t.msDeployer.EXPECT().Deploy(mock.Anything, mock.Anything).RunAndReturn(machineSetFn(&machineSets)).Times(2)
 
 			t.numGateways = 2

--- a/pkg/ocp/fake/machineset.go
+++ b/pkg/ocp/fake/machineset.go
@@ -25,6 +25,7 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
+	"github.com/submariner-io/cloud-prepare/pkg/ocp"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -195,22 +196,22 @@ func (_c *MockMachineSetDeployer_Deploy_Call) RunAndReturn(run func(ctx context.
 }
 
 // GetWorkerNodeImage provides a mock function for the type MockMachineSetDeployer
-func (_mock *MockMachineSetDeployer) GetWorkerNodeImage(ctx context.Context, machineSet *unstructured.Unstructured, infraID string) (string, error) {
+func (_mock *MockMachineSetDeployer) GetWorkerNodeImage(ctx context.Context, machineSet *unstructured.Unstructured, infraID string) (ocp.ImageSpec, error) {
 	ret := _mock.Called(ctx, machineSet, infraID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetWorkerNodeImage")
 	}
 
-	var r0 string
+	var r0 ocp.ImageSpec
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured, string) (string, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured, string) (ocp.ImageSpec, error)); ok {
 		return returnFunc(ctx, machineSet, infraID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured, string) string); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *unstructured.Unstructured, string) ocp.ImageSpec); ok {
 		r0 = returnFunc(ctx, machineSet, infraID)
 	} else {
-		r0 = ret.Get(0).(string)
+		r0 = ret.Get(0).(ocp.ImageSpec)
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, *unstructured.Unstructured, string) error); ok {
 		r1 = returnFunc(ctx, machineSet, infraID)
@@ -240,12 +241,12 @@ func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) Run(run func(ctx conte
 	return _c
 }
 
-func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) Return(s string, err error) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
-	_c.Call.Return(s, err)
+func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) Return(imageSpec ocp.ImageSpec, err error) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
+	_c.Call.Return(imageSpec, err)
 	return _c
 }
 
-func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) RunAndReturn(run func(ctx context.Context, machineSet *unstructured.Unstructured, infraID string) (string, error)) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
+func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) RunAndReturn(run func(ctx context.Context, machineSet *unstructured.Unstructured, infraID string) (ocp.ImageSpec, error)) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/ocp/machinesets.go
+++ b/pkg/ocp/machinesets.go
@@ -42,13 +42,27 @@ const (
 	SubmarinerGatewayLabel = "submariner.io/gateway"
 )
 
+// ImageSpec describes the image used by a worker node MachineSet.
+// Different cloud providers populate different fields:
+//   - GCP and RHOS use Image (a plain image name or path).
+//   - Azure custom/managed images use ResourceID.
+//   - Azure Marketplace images use Offer, Publisher, SKU, Version, and Type.
+type ImageSpec struct {
+	// Image is the plain image name or path (used by GCP and RHOS).
+	Image string
+	// ResourceID is the Azure resource ID for a custom or managed image.
+	ResourceID string
+	// Offer, Publisher, SKU, Version, Type are the Azure Marketplace image fields.
+	Offer, Publisher, SKU, Version, Type string
+}
+
 // MachineSetDeployer can deploy and delete machinesets from OCP.
 type MachineSetDeployer interface {
 	// Deploy makes sure to deploy the given machine set (creating or updating it).
 	Deploy(ctx context.Context, machineSet *unstructured.Unstructured) error
 
-	// GetWorkerNodeImage returns the image used by OCP worker nodes.
-	GetWorkerNodeImage(ctx context.Context, machineSet *unstructured.Unstructured, infraID string) (string, error)
+	// GetWorkerNodeImage returns the ImageSpec describing the image used by OCP worker nodes.
+	GetWorkerNodeImage(ctx context.Context, machineSet *unstructured.Unstructured, infraID string) (ImageSpec, error)
 
 	// List will list all the machineSets that have the submariner.io/gateway set to "true".
 	List(ctx context.Context) ([]unstructured.Unstructured, error)
@@ -95,7 +109,7 @@ func (msd *k8sMachineSetDeployer) clientForMsd(nameSpace string) dynamic.Resourc
 }
 
 func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(ctx context.Context, machineSet *unstructured.Unstructured, infraID string,
-) (string, error) {
+) (ImageSpec, error) {
 	machineSetClient := msd.clientForMsd("openshift-machine-api")
 
 	if machineSet != nil {
@@ -103,13 +117,13 @@ func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(ctx context.Context, machin
 
 		machineSetClient, err = msd.clientFor(machineSet)
 		if err != nil {
-			return "", err
+			return ImageSpec{}, err
 		}
 	}
 
 	nodeList, err := machineSetClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return "", errors.Wrapf(err, "error listing the machineSets")
+		return ImageSpec{}, errors.Wrapf(err, "error listing the machineSets")
 	}
 
 	for i := range nodeList.Items {
@@ -120,38 +134,59 @@ func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(ctx context.Context, machin
 			}
 		}
 
-		if image := getImageFromMachineSet(&nodeList.Items[i]); image != "" {
+		if image, ok := getImageFromMachineSet(&nodeList.Items[i]); ok {
 			return image, nil
 		}
 	}
 
-	return "", fmt.Errorf("could not retrieve the image of one of the worker nodes from the infra %q", infraID)
+	return ImageSpec{}, fmt.Errorf("could not retrieve the image of one of the worker nodes from the infra %q", infraID)
 }
 
-func getImageFromMachineSet(existing *unstructured.Unstructured) string {
+func getImageFromMachineSet(existing *unstructured.Unstructured) (ImageSpec, bool) {
 	disks, _, _ := unstructured.NestedSlice(existing.Object, "spec", "template", "spec", "providerSpec", "value", "disks")
 	for _, o := range disks {
 		disk := o.(map[string]any)
 
 		image, _, _ := unstructured.NestedString(disk, "image")
 		if image != "" {
-			return image
+			return ImageSpec{Image: image}, true
 		}
 	}
 
 	image, _, _ := unstructured.NestedString(existing.Object, "spec", "template", "spec", "providerSpec", "value", "image")
 	if image != "" {
-		return image
+		return ImageSpec{Image: image}, true
 	}
 
-	// For MachineSets deployed in Azure.
-	image, _, _ = unstructured.NestedString(existing.Object, "spec", "template", "spec", "providerSpec",
-		"value", "image", "resourceID")
-	if image != "" {
-		return image
+	// For MachineSets deployed in Azure: prefer ResourceID, fall back to Marketplace fields.
+	imageMap, found, _ := unstructured.NestedMap(existing.Object, "spec", "template", "spec", "providerSpec", "value", "image")
+	if !found {
+		return ImageSpec{}, false
 	}
 
-	return ""
+	resourceID, _, _ := unstructured.NestedString(imageMap, "resourceID")
+	if resourceID != "" {
+		return ImageSpec{ResourceID: resourceID}, true
+	}
+
+	// Azure Marketplace image: all five fields must be present.
+	offer, _, _ := unstructured.NestedString(imageMap, "offer")
+	publisher, _, _ := unstructured.NestedString(imageMap, "publisher")
+	sku, _, _ := unstructured.NestedString(imageMap, "sku")
+	version, _, _ := unstructured.NestedString(imageMap, "version")
+	imageType, _, _ := unstructured.NestedString(imageMap, "type")
+
+	if offer != "" && publisher != "" && sku != "" && version != "" && imageType != "" {
+		return ImageSpec{
+			Offer:     offer,
+			Publisher: publisher,
+			SKU:       sku,
+			Version:   version,
+			Type:      imageType,
+		}, true
+	}
+
+	return ImageSpec{}, false
 }
 
 func (msd *k8sMachineSetDeployer) Deploy(ctx context.Context, machineSet *unstructured.Unstructured) error {

--- a/pkg/ocp/machinesets_test.go
+++ b/pkg/ocp/machinesets_test.go
@@ -78,7 +78,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				Expect(err).To(Succeed())
 			})
 
-			Context("", func() {
+			Context("with a disk image", func() {
 				BeforeEach(func() {
 					disks := []any{
 						map[string]any{
@@ -92,11 +92,68 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				It("should return its disk image", func(ctx SpecContext) {
 					image, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
 					Expect(err).To(Succeed())
-					Expect(image).To(Equal("some-image"))
+					Expect(image.Image).To(Equal("some-image"))
 				})
 			})
 
-			Context("and has no disks", func() {
+			Context("with an Azure resourceID image", func() {
+				BeforeEach(func() {
+					_ = unstructured.SetNestedField(machineSet.Object, "/subscriptions/abc/images/myimage",
+						"spec", "template", "spec", "providerSpec", "value", "image", "resourceID")
+				})
+
+				It("should return the ResourceID", func(ctx SpecContext) {
+					image, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
+					Expect(err).To(Succeed())
+					Expect(image.ResourceID).To(Equal("/subscriptions/abc/images/myimage"))
+				})
+			})
+
+			Context("with an Azure Marketplace image", func() {
+				BeforeEach(func() {
+					imageMap := map[string]any{
+						"offer":      "aro4",
+						"publisher":  "azureopenshift",
+						"resourceID": "",
+						"sku":        "420-v2",
+						"version":    "9.6.20251015",
+						"type":       "MarketplaceNoPlan",
+					}
+
+					_ = unstructured.SetNestedMap(machineSet.Object, imageMap,
+						"spec", "template", "spec", "providerSpec", "value", "image")
+				})
+
+				It("should return the Marketplace image fields", func(ctx SpecContext) {
+					image, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
+					Expect(err).To(Succeed())
+					Expect(image.Offer).To(Equal("aro4"))
+					Expect(image.Publisher).To(Equal("azureopenshift"))
+					Expect(image.SKU).To(Equal("420-v2"))
+					Expect(image.Version).To(Equal("9.6.20251015"))
+					Expect(image.Type).To(Equal("MarketplaceNoPlan"))
+				})
+			})
+
+			Context("with a partial Azure Marketplace image (missing fields)", func() {
+				BeforeEach(func() {
+					imageMap := map[string]any{
+						"offer":     "aro4",
+						"publisher": "azureopenshift",
+						// sku, version, and type are intentionally missing
+					}
+
+					_ = unstructured.SetNestedMap(machineSet.Object, imageMap,
+						"spec", "template", "spec", "providerSpec", "value", "image")
+				})
+
+				It("should return an error", func(ctx SpecContext) {
+					_, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
+					Expect(err).ToNot(Succeed())
+				})
+			})
+
+			Context("and has no image", func() {
 				It("should return an error", func(ctx SpecContext) {
 					_, err := deployer.GetWorkerNodeImage(ctx, machineSet, infraID)
 					Expect(err).ToNot(Succeed())

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -122,10 +122,12 @@ func (d *ocpGatewayDeployer) deployGateway(ctx context.Context, useInternalSG bo
 	}
 
 	if d.image == "" {
-		d.image, err = d.msDeployer.GetWorkerNodeImage(ctx, machineSet, d.InfraID)
+		imageSpec, err := d.msDeployer.GetWorkerNodeImage(ctx, machineSet, d.InfraID)
 		if err != nil {
 			return errors.Wrap(err, "error getting the worker image")
 		}
+
+		d.image = imageSpec.Image
 
 		machineSet, err = d.initMachineSet(useInternalSG)
 		if err != nil {

--- a/pkg/rhos/ocpgwdeployer_test.go
+++ b/pkg/rhos/ocpgwdeployer_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/cloud-prepare/pkg/api"
 	"github.com/submariner-io/cloud-prepare/pkg/k8s"
+	"github.com/submariner-io/cloud-prepare/pkg/ocp"
 	ocpfake "github.com/submariner-io/cloud-prepare/pkg/ocp/fake"
 	"github.com/submariner-io/cloud-prepare/pkg/rhos"
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +50,7 @@ func testDeploy() {
 	t := newGatewayDeployerTestDriver()
 
 	BeforeEach(func() {
-		t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, mock.Anything, testInfraID).Return(testImage, nil).Maybe()
+		t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, mock.Anything, testInfraID).Return(ocp.ImageSpec{Image: testImage}, nil).Maybe()
 	})
 
 	It("should deploy a gateway node machine set and security group rules", func(ctx SpecContext) {


### PR DESCRIPTION
Backport of #1328 on release-0.23.

#1328: Support Azure Marketplace images for gateway MachineSet

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled comprehensive Azure Marketplace image configuration support for gateway deployments

* **Refactor**
  * Enhanced image specification structure to uniformly handle multiple image sources across cloud providers (custom resource IDs, Azure Marketplace fields, cloud-native image formats)
  * Improved consistency of worker node image retrieval and configuration in gateway deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->