### PR TITLE
 Backport of #1328: Support Azure Marketplace images for gateway MachineSet

### DIFF
--- a/pkg/azure/gw-machineset.go
+++ b/pkg/azure/gw-machineset.go
@@ -55,11 +55,12 @@ spec:
             name: azure-cloud-credentials
             namespace: openshift-machine-api
           image:
-            offer: ""
-            publisher: ""
-            resourceID: {{.Image}} 
-            sku: ""
-            version: ""
+            offer: "{{.ImageOffer}}"
+            publisher: "{{.ImagePublisher}}"
+            resourceID: "{{.ImageResourceID}}"
+            sku: "{{.ImageSKU}}"
+            version: "{{.ImageVersion}}"
+            type: "{{.ImageType}}"
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
           location: {{.Region}}

--- a/pkg/azure/ocpgwdeployer.go
+++ b/pkg/azure/ocpgwdeployer.go
@@ -127,16 +127,11 @@ func (d *ocpGatewayDeployer) Deploy(input api.GatewayDeployInput, status reporte
 		return errors.Wrap(imageErr, "error retrieving worker node image")
 	}
 
-	err = d.deployDedicatedGWNode(machineSets, gatewayNodesToDeploy, input.AirGapped, image, status)
-	if err != nil {
-		status.Success("Deployed gateway node")
-	}
-
-	return err
+	return d.deployDedicatedGWNode(machineSets, gatewayNodesToDeploy, input.AirGapped, &image, status)
 }
 
-func (d *ocpGatewayDeployer) deployDedicatedGWNode(gwNodes []unstructured.Unstructured, gatewayNodesToDeploy int,
-	airGapped bool, image string, status reporter.Interface,
+func (d *ocpGatewayDeployer) deployDedicatedGWNode(gwNodes []unstructured.Unstructured,
+	gatewayNodesToDeploy int, airGapped bool, image *ocp.ImageSpec, status reporter.Interface,
 ) error {
 	az, err := d.getAvailabilityZones(gwNodes)
 	if err != nil || az.Len() == 0 {
@@ -166,16 +161,21 @@ func (d *ocpGatewayDeployer) deployDedicatedGWNode(gwNodes []unstructured.Unstru
 }
 
 type machineSetConfig struct {
-	Name         string
-	AZ           string
-	InfraID      string
-	InstanceType string
-	Region       string
-	Image        string
-	PublicIP     string
+	Name            string
+	AZ              string
+	InfraID         string
+	InstanceType    string
+	Region          string
+	ImageResourceID string
+	ImageOffer      string
+	ImagePublisher  string
+	ImageSKU        string
+	ImageVersion    string
+	ImageType       string
+	PublicIP        string
 }
 
-func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone, image string, airGapped bool) ([]byte, error) {
+func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone string, image *ocp.ImageSpec, airGapped bool) ([]byte, error) {
 	var buf bytes.Buffer
 
 	tpl, err := template.New("").Parse(machineSetYAML)
@@ -184,13 +184,18 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone, image string, airGapped
 	}
 
 	tplVars := machineSetConfig{
-		Name:         name,
-		InfraID:      d.azure.InfraID,
-		InstanceType: d.instanceType,
-		Region:       d.azure.Region,
-		AZ:           zone,
-		Image:        image,
-		PublicIP:     strconv.FormatBool(!airGapped),
+		Name:            name,
+		InfraID:         d.azure.InfraID,
+		InstanceType:    d.instanceType,
+		Region:          d.azure.Region,
+		AZ:              zone,
+		ImageResourceID: image.ResourceID,
+		ImageOffer:      image.Offer,
+		ImagePublisher:  image.Publisher,
+		ImageSKU:        image.SKU,
+		ImageVersion:    image.Version,
+		ImageType:       image.Type,
+		PublicIP:        strconv.FormatBool(!airGapped),
 	}
 
 	err = tpl.Execute(&buf, tplVars)
@@ -201,7 +206,7 @@ func (d *ocpGatewayDeployer) loadGatewayYAML(name, zone, image string, airGapped
 	return buf.Bytes(), nil
 }
 
-func (d *ocpGatewayDeployer) initMachineSet(name, zone, image string, airGapped bool) (*unstructured.Unstructured, error) {
+func (d *ocpGatewayDeployer) initMachineSet(name, zone string, image *ocp.ImageSpec, airGapped bool) (*unstructured.Unstructured, error) {
 	gatewayYAML, err := d.loadGatewayYAML(name, zone, image, airGapped)
 	if err != nil {
 		return nil, err
@@ -219,7 +224,7 @@ func (d *ocpGatewayDeployer) initMachineSet(name, zone, image string, airGapped 
 	return machineSet, nil
 }
 
-func (d *ocpGatewayDeployer) deployGateway(zone, image string, airGapped bool) error {
+func (d *ocpGatewayDeployer) deployGateway(zone string, image *ocp.ImageSpec, airGapped bool) error {
 	machineSet, err := d.initMachineSet(MachineName(d.azure.Region), zone, image, airGapped)
 	if err != nil {
 		return err

--- a/pkg/azure/ocpgwdeployer_internal_test.go
+++ b/pkg/azure/ocpgwdeployer_internal_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	"github.com/submariner-io/admiral/pkg/util"
+	"github.com/submariner-io/cloud-prepare/pkg/ocp"
 	ocpFake "github.com/submariner-io/cloud-prepare/pkg/ocp/fake"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
@@ -34,7 +35,6 @@ var _ = Describe("OCP Gateway Deployer", func() {
 	const (
 		infraID      = "test-infraID"
 		region       = "east"
-		image        = "test-image"
 		zone         = "east-zone"
 		instanceType = "large"
 	)
@@ -72,21 +72,23 @@ var _ = Describe("OCP Gateway Deployer", func() {
 		})
 
 		It("should deploy the correct MachineSet", func() {
-			Expect(gwDeployer.deployGateway(zone, image, false)).To(Succeed())
+			imgSpec := &ocp.ImageSpec{ResourceID: "test-image"}
+			Expect(gwDeployer.deployGateway(zone, imgSpec, false)).To(Succeed())
 
 			Expect(machineSet).ToNot(BeNil())
 			Expect(machineSet.GetLabels()).To(HaveKeyWithValue("machine.openshift.io/cluster-api-cluster", infraID))
 			Expect(util.GetNestedField(machineSet, "metadata", "name")).To(HavePrefix(submarinerGatewayGW + region))
 			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "metadata", "labels")).
 				To(HaveKeyWithValue("submariner.io/gateway", "true"))
-			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "image", "resourceID")).To(Equal(image))
+			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "image", "resourceID")).
+				To(Equal(imgSpec.ResourceID))
 			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "location")).To(Equal(region))
 			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "zone")).To(Equal(zone))
 			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "vmSize")).To(Equal(instanceType))
 			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "publicIP")).To(BeTrue())
 
 			machineSet = nil
-			Expect(gwDeployer.deployGateway(zone, image, true)).To(Succeed())
+			Expect(gwDeployer.deployGateway(zone, imgSpec, true)).To(Succeed())
 
 			Expect(machineSet).ToNot(BeNil())
 			Expect(util.GetNestedField(machineSet, "spec", "template", "spec", "providerSpec", "value", "publicIP")).To(BeFalse())

--- a/pkg/gcp/ocpgwdeployer.go
+++ b/pkg/gcp/ocpgwdeployer.go
@@ -233,10 +233,12 @@ func (d *ocpGatewayDeployer) deployGateway(zone string) error {
 	}
 
 	if d.image == "" {
-		d.image, err = d.msDeployer.GetWorkerNodeImage(machineSet, d.InfraID)
+		imageSpec, err := d.msDeployer.GetWorkerNodeImage(machineSet, d.InfraID)
 		if err != nil {
 			return errors.Wrap(err, "error retrieving worker node image")
 		}
+
+		d.image = imageSpec.Image
 
 		machineSet, err = d.initMachineSet(zone)
 		if err != nil {

--- a/pkg/gcp/ocpgwdeployer_test.go
+++ b/pkg/gcp/ocpgwdeployer_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/submariner-io/cloud-prepare/pkg/api"
 	"github.com/submariner-io/cloud-prepare/pkg/gcp"
 	"github.com/submariner-io/cloud-prepare/pkg/k8s"
+	"github.com/submariner-io/cloud-prepare/pkg/ocp"
 	ocpFake "github.com/submariner-io/cloud-prepare/pkg/ocp/fake"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -124,7 +125,7 @@ func testDeploy() {
 		var machineSets map[string]*unstructured.Unstructured
 
 		BeforeEach(func() {
-			t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, infraID).Return("test-image", nil).Maybe()
+			t.msDeployer.EXPECT().GetWorkerNodeImage(mock.Anything, infraID).Return(ocp.ImageSpec{Image: "test-image"}, nil).Maybe()
 			t.msDeployer.EXPECT().Deploy(mock.Anything).RunAndReturn(machineSetFn(&machineSets)).Times(2)
 
 			t.numGateways = 2

--- a/pkg/ocp/fake/machineset.go
+++ b/pkg/ocp/fake/machineset.go
@@ -23,6 +23,7 @@ package fake
 
 import (
 	mock "github.com/stretchr/testify/mock"
+	"github.com/submariner-io/cloud-prepare/pkg/ocp"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -190,22 +191,22 @@ func (_c *MockMachineSetDeployer_Deploy_Call) RunAndReturn(run func(machineSet *
 }
 
 // GetWorkerNodeImage provides a mock function for the type MockMachineSetDeployer
-func (_mock *MockMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured.Unstructured, infraID string) (string, error) {
+func (_mock *MockMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured.Unstructured, infraID string) (ocp.ImageSpec, error) {
 	ret := _mock.Called(machineSet, infraID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetWorkerNodeImage")
 	}
 
-	var r0 string
+	var r0 ocp.ImageSpec
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*unstructured.Unstructured, string) (string, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(*unstructured.Unstructured, string) (ocp.ImageSpec, error)); ok {
 		return returnFunc(machineSet, infraID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*unstructured.Unstructured, string) string); ok {
+	if returnFunc, ok := ret.Get(0).(func(*unstructured.Unstructured, string) ocp.ImageSpec); ok {
 		r0 = returnFunc(machineSet, infraID)
 	} else {
-		r0 = ret.Get(0).(string)
+		r0 = ret.Get(0).(ocp.ImageSpec)
 	}
 	if returnFunc, ok := ret.Get(1).(func(*unstructured.Unstructured, string) error); ok {
 		r1 = returnFunc(machineSet, infraID)
@@ -234,12 +235,12 @@ func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) Run(run func(machineSe
 	return _c
 }
 
-func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) Return(s string, err error) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
-	_c.Call.Return(s, err)
+func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) Return(imageSpec ocp.ImageSpec, err error) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
+	_c.Call.Return(imageSpec, err)
 	return _c
 }
 
-func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) RunAndReturn(run func(machineSet *unstructured.Unstructured, infraID string) (string, error)) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
+func (_c *MockMachineSetDeployer_GetWorkerNodeImage_Call) RunAndReturn(run func(machineSet *unstructured.Unstructured, infraID string) (ocp.ImageSpec, error)) *MockMachineSetDeployer_GetWorkerNodeImage_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/ocp/machinesets.go
+++ b/pkg/ocp/machinesets.go
@@ -42,13 +42,27 @@ const (
 	SubmarinerGatewayLabel = "submariner.io/gateway"
 )
 
+// ImageSpec describes the image used by a worker node MachineSet.
+// Different cloud providers populate different fields:
+//   - GCP and RHOS use Image (a plain image name or path).
+//   - Azure custom/managed images use ResourceID.
+//   - Azure Marketplace images use Offer, Publisher, SKU, Version, and Type.
+type ImageSpec struct {
+	// Image is the plain image name or path (used by GCP and RHOS).
+	Image string
+	// ResourceID is the Azure resource ID for a custom or managed image.
+	ResourceID string
+	// Offer, Publisher, SKU, Version, Type are the Azure Marketplace image fields.
+	Offer, Publisher, SKU, Version, Type string
+}
+
 // MachineSetDeployer can deploy and delete machinesets from OCP.
 type MachineSetDeployer interface {
 	// Deploy makes sure to deploy the given machine set (creating or updating it).
 	Deploy(machineSet *unstructured.Unstructured) error
 
-	// GetWorkerNodeImage returns the image used by OCP worker nodes.
-	GetWorkerNodeImage(machineSet *unstructured.Unstructured, infraID string) (string, error)
+	// GetWorkerNodeImage returns the ImageSpec describing the image used by OCP worker nodes.
+	GetWorkerNodeImage(machineSet *unstructured.Unstructured, infraID string) (ImageSpec, error)
 
 	// List will list all the machineSets that have the submariner.io/gateway set to "true".
 	List() ([]unstructured.Unstructured, error)
@@ -95,7 +109,7 @@ func (msd *k8sMachineSetDeployer) clientForMsd(nameSpace string) dynamic.Resourc
 }
 
 func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured.Unstructured, infraID string,
-) (string, error) {
+) (ImageSpec, error) {
 	machineSetClient := msd.clientForMsd("openshift-machine-api")
 
 	if machineSet != nil {
@@ -103,13 +117,13 @@ func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured.Un
 
 		machineSetClient, err = msd.clientFor(machineSet)
 		if err != nil {
-			return "", err
+			return ImageSpec{}, err
 		}
 	}
 
 	nodeList, err := machineSetClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return "", errors.Wrapf(err, "error listing the machineSets")
+		return ImageSpec{}, errors.Wrapf(err, "error listing the machineSets")
 	}
 
 	for i := range nodeList.Items {
@@ -120,38 +134,59 @@ func (msd *k8sMachineSetDeployer) GetWorkerNodeImage(machineSet *unstructured.Un
 			}
 		}
 
-		if image := getImageFromMachineSet(&nodeList.Items[i]); image != "" {
+		if image, ok := getImageFromMachineSet(&nodeList.Items[i]); ok {
 			return image, nil
 		}
 	}
 
-	return "", fmt.Errorf("could not retrieve the image of one of the worker nodes from the infra %q", infraID)
+	return ImageSpec{}, fmt.Errorf("could not retrieve the image of one of the worker nodes from the infra %q", infraID)
 }
 
-func getImageFromMachineSet(existing *unstructured.Unstructured) string {
+func getImageFromMachineSet(existing *unstructured.Unstructured) (ImageSpec, bool) {
 	disks, _, _ := unstructured.NestedSlice(existing.Object, "spec", "template", "spec", "providerSpec", "value", "disks")
 	for _, o := range disks {
 		disk := o.(map[string]interface{})
 
 		image, _, _ := unstructured.NestedString(disk, "image")
 		if image != "" {
-			return image
+			return ImageSpec{Image: image}, true
 		}
 	}
 
 	image, _, _ := unstructured.NestedString(existing.Object, "spec", "template", "spec", "providerSpec", "value", "image")
 	if image != "" {
-		return image
+		return ImageSpec{Image: image}, true
 	}
 
-	// For MachineSets deployed in Azure.
-	image, _, _ = unstructured.NestedString(existing.Object, "spec", "template", "spec", "providerSpec",
-		"value", "image", "resourceID")
-	if image != "" {
-		return image
+	// For MachineSets deployed in Azure: prefer ResourceID, fall back to Marketplace fields.
+	imageMap, found, _ := unstructured.NestedMap(existing.Object, "spec", "template", "spec", "providerSpec", "value", "image")
+	if !found {
+		return ImageSpec{}, false
 	}
 
-	return ""
+	resourceID, _, _ := unstructured.NestedString(imageMap, "resourceID")
+	if resourceID != "" {
+		return ImageSpec{ResourceID: resourceID}, true
+	}
+
+	// Azure Marketplace image: all five fields must be present.
+	offer, _, _ := unstructured.NestedString(imageMap, "offer")
+	publisher, _, _ := unstructured.NestedString(imageMap, "publisher")
+	sku, _, _ := unstructured.NestedString(imageMap, "sku")
+	version, _, _ := unstructured.NestedString(imageMap, "version")
+	imageType, _, _ := unstructured.NestedString(imageMap, "type")
+
+	if offer != "" && publisher != "" && sku != "" && version != "" && imageType != "" {
+		return ImageSpec{
+			Offer:     offer,
+			Publisher: publisher,
+			SKU:       sku,
+			Version:   version,
+			Type:      imageType,
+		}, true
+	}
+
+	return ImageSpec{}, false
 }
 
 func (msd *k8sMachineSetDeployer) Deploy(machineSet *unstructured.Unstructured) error {

--- a/pkg/ocp/machinesets_test.go
+++ b/pkg/ocp/machinesets_test.go
@@ -79,7 +79,7 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				Expect(err).To(Succeed())
 			})
 
-			Context("", func() {
+			Context("with a disk image", func() {
 				BeforeEach(func() {
 					disks := []interface{}{
 						map[string]interface{}{
@@ -93,11 +93,68 @@ var _ = Describe("K8s MachineSetDeployer", func() {
 				It("should return its disk image", func() {
 					image, err := deployer.GetWorkerNodeImage(machineSet, infraID)
 					Expect(err).To(Succeed())
-					Expect(image).To(Equal("some-image"))
+					Expect(image.Image).To(Equal("some-image"))
 				})
 			})
 
-			Context("and has no disks", func() {
+			Context("with an Azure resourceID image", func() {
+				BeforeEach(func() {
+					_ = unstructured.SetNestedField(machineSet.Object, "/subscriptions/abc/images/myimage",
+						"spec", "template", "spec", "providerSpec", "value", "image", "resourceID")
+				})
+
+				It("should return the ResourceID", func() {
+					image, err := deployer.GetWorkerNodeImage(machineSet, infraID)
+					Expect(err).To(Succeed())
+					Expect(image.ResourceID).To(Equal("/subscriptions/abc/images/myimage"))
+				})
+			})
+
+			Context("with an Azure Marketplace image", func() {
+				BeforeEach(func() {
+					imageMap := map[string]any{
+						"offer":      "aro4",
+						"publisher":  "azureopenshift",
+						"resourceID": "",
+						"sku":        "420-v2",
+						"version":    "9.6.20251015",
+						"type":       "MarketplaceNoPlan",
+					}
+
+					_ = unstructured.SetNestedMap(machineSet.Object, imageMap,
+						"spec", "template", "spec", "providerSpec", "value", "image")
+				})
+
+				It("should return the Marketplace image fields", func() {
+					image, err := deployer.GetWorkerNodeImage(machineSet, infraID)
+					Expect(err).To(Succeed())
+					Expect(image.Offer).To(Equal("aro4"))
+					Expect(image.Publisher).To(Equal("azureopenshift"))
+					Expect(image.SKU).To(Equal("420-v2"))
+					Expect(image.Version).To(Equal("9.6.20251015"))
+					Expect(image.Type).To(Equal("MarketplaceNoPlan"))
+				})
+			})
+
+			Context("with a partial Azure Marketplace image (missing fields)", func() {
+				BeforeEach(func() {
+					imageMap := map[string]any{
+						"offer":     "aro4",
+						"publisher": "azureopenshift",
+						// sku, version, and type are intentionally missing
+					}
+
+					_ = unstructured.SetNestedMap(machineSet.Object, imageMap,
+						"spec", "template", "spec", "providerSpec", "value", "image")
+				})
+
+				It("should return an error", func() {
+					_, err := deployer.GetWorkerNodeImage(machineSet, infraID)
+					Expect(err).ToNot(Succeed())
+				})
+			})
+
+			Context("and has no image", func() {
 				It("should return an error", func() {
 					_, err := deployer.GetWorkerNodeImage(machineSet, infraID)
 					Expect(err).ToNot(Succeed())

--- a/pkg/rhos/ocpgwdeployer.go
+++ b/pkg/rhos/ocpgwdeployer.go
@@ -118,10 +118,12 @@ func (d *ocpGatewayDeployer) deployGateway(useInternalSG bool) error {
 	}
 
 	if d.image == "" {
-		d.image, err = d.msDeployer.GetWorkerNodeImage(machineSet, d.InfraID)
+		imageSpec, err := d.msDeployer.GetWorkerNodeImage(machineSet, d.InfraID)
 		if err != nil {
 			return errors.Wrap(err, "error getting the worker image")
 		}
+
+		d.image = imageSpec.Image
 
 		machineSet, err = d.initMachineSet(useInternalSG)
 		if err != nil {


### PR DESCRIPTION
Backport of #1328 on release-0.22.

#1328: Support Azure Marketplace images for gateway MachineSet

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified worker-node image handling to use a structured image spec, enabling Azure resourceID and Marketplace image fields (offer, publisher, SKU, version, type) and updating machine set templates to consume those variables.

* **Bug Fixes**
  * Deployment now propagates image retrieval errors instead of treating failed lookups as successful.

* **Tests**
  * Expanded tests to cover disk images, Azure resourceID, full and partial Marketplace image scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->